### PR TITLE
Use stock Symfony event listener for entity changes

### DIFF
--- a/DependencyInjection/CompilerPass/RegisterPurgerImplementationCompilerPass.php
+++ b/DependencyInjection/CompilerPass/RegisterPurgerImplementationCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SofaScore\Purgatory\DependencyInjection\CompilerPass;
+
+use SofaScore\Purgatory\Purger\PurgerInterface;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+final class RegisterPurgerImplementationCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        /** @var string $serviceId */
+        $serviceId = $container->getParameter('sofascore.purgatory.purger');
+
+        // Don't pollute the container with unnecessary metadata.
+        $container->getParameterBag()->remove('sofascore.purgatory.purger');
+
+        $purgerImplementation = $container->findDefinition($serviceId);
+
+        if (!is_a($purgerImplementation->getClass(), PurgerInterface::class, true)) {
+            throw new \LogicException(
+                sprintf('The purger service should implement the \'%s\' interface.', PurgerInterface::class)
+            );
+        }
+
+        $container->setAlias('sofascore.purgatory.purger', new Alias($serviceId, false));
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,9 +11,24 @@ final class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress PossiblyNullReference
+     * @psalm-suppress PossiblyUndefinedMethod
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        return new TreeBuilder('purgatory');
+        $treeBuilder = new TreeBuilder('purgatory');
+        $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode
+            ->children()
+                ->booleanNode('entity_change_listener')
+                    ->info('Determines whether entity changes should trigger the configured purge mechanism automatically.')
+                    ->defaultTrue()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('purger')
                     ->info('ID of the service implementing the \'SofaScore\Purgatory\Purger\PurgerInterface\' interface.')
+                    ->isRequired()
                     ->cannotBeEmpty()
                 ->end()
                 ->booleanNode('entity_change_listener')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,10 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('purger')
+                    ->info('ID of the service implementing the \'SofaScore\Purgatory\Purger\PurgerInterface\' interface.')
+                    ->cannotBeEmpty()
+                ->end()
                 ->booleanNode('entity_change_listener')
                     ->info('Determines whether entity changes should trigger the configured purge mechanism automatically.')
                     ->defaultTrue()

--- a/DependencyInjection/PurgatoryExtension.php
+++ b/DependencyInjection/PurgatoryExtension.php
@@ -19,6 +19,10 @@ final class PurgatoryExtension extends Extension
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
         $loader->load('services.php');
 
-        $this->processConfiguration(new Configuration(), $configs);
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        if (!$config['entity_change_listener']) {
+            $container->removeDefinition('sofascore.purgatory.cache_refresh.entity_change_listener');
+        }
     }
 }

--- a/DependencyInjection/PurgatoryExtension.php
+++ b/DependencyInjection/PurgatoryExtension.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace SofaScore\Purgatory\DependencyInjection;
 
-use SofaScore\Purgatory\Purger\PurgerInterface;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -23,23 +21,10 @@ final class PurgatoryExtension extends Extension
 
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        $this->configurePurgerService($container, $config['purger']);
+        $container->setParameter('sofascore.purgatory.purger', $config['purger']);
 
         if (!$config['entity_change_listener']) {
             $container->removeDefinition('sofascore.purgatory.entity_change_listener');
         }
-    }
-
-    private function configurePurgerService(ContainerBuilder $container, string $serviceId): void
-    {
-        $webCacheImplementation = $container->getDefinition($serviceId);
-
-        if (!is_a($webCacheImplementation->getClass(), PurgerInterface::class, true)) {
-            throw new \LogicException(
-                sprintf('The purger service should implement the \'%s\' interface.', PurgerInterface::class)
-            );
-        }
-
-        $container->setAlias('sofascore.purgatory.purger', new Alias($serviceId, false));
     }
 }

--- a/DependencyInjection/PurgatoryExtension.php
+++ b/DependencyInjection/PurgatoryExtension.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace SofaScore\Purgatory\DependencyInjection;
 
+use SofaScore\Purgatory\Purger\PurgerInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -21,8 +23,23 @@ final class PurgatoryExtension extends Extension
 
         $config = $this->processConfiguration(new Configuration(), $configs);
 
+        $this->configurePurgerService($container, $config['purger']);
+
         if (!$config['entity_change_listener']) {
             $container->removeDefinition('sofascore.purgatory.cache_refresh.entity_change_listener');
         }
+    }
+
+    private function configurePurgerService(ContainerBuilder $container, string $serviceId): void
+    {
+        $webCacheImplementation = $container->getDefinition($serviceId);
+
+        if (!is_a($webCacheImplementation->getClass(), PurgerInterface::class, true)) {
+            throw new \LogicException(
+                sprintf('The purger service should implement the \'%s\' interface.', PurgerInterface::class)
+            );
+        }
+
+        $container->setAlias('sofascore.purgatory.purger', new Alias($serviceId, false));
     }
 }

--- a/DependencyInjection/PurgatoryExtension.php
+++ b/DependencyInjection/PurgatoryExtension.php
@@ -26,7 +26,7 @@ final class PurgatoryExtension extends Extension
         $this->configurePurgerService($container, $config['purger']);
 
         if (!$config['entity_change_listener']) {
-            $container->removeDefinition('sofascore.purgatory.cache_refresh.entity_change_listener');
+            $container->removeDefinition('sofascore.purgatory.entity_change_listener');
         }
     }
 

--- a/Mapping/Loader/AnnotationsLoader.php
+++ b/Mapping/Loader/AnnotationsLoader.php
@@ -50,7 +50,7 @@ class AnnotationsLoader implements LoaderInterface, WarmableInterface
 
         // instantiate cache
         $cache = new ConfigCache(
-            $this->config->getCacheDir() . '/cache_refresh/mappings/collection.php', $this->config->getDebug()
+            $this->config->getCacheDir() . '/purgatory/mappings/collection.php', $this->config->getDebug()
         );
 
         // write cache if not fresh

--- a/PurgatoryBundle.php
+++ b/PurgatoryBundle.php
@@ -2,8 +2,19 @@
 
 namespace SofaScore\Purgatory;
 
+use SofaScore\Purgatory\DependencyInjection\CompilerPass\RegisterPurgerImplementationCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class PurgatoryBundle extends Bundle
+final class PurgatoryBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new RegisterPurgerImplementationCompilerPass());
+    }
 }

--- a/Purger/PurgerInterface.php
+++ b/Purger/PurgerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SofaScore\Purgatory\Purger;
+
+interface PurgerInterface
+{
+    public function purge(iterable $urls): void;
+}

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -11,7 +11,6 @@ use SofaScore\Purgatory\Listener\EntityChangeListener;
 use SofaScore\Purgatory\Mapping\CacheWarmer\AnnotationsLoaderWarmer;
 use SofaScore\Purgatory\Mapping\Loader\AnnotationsLoader;
 use SofaScore\Purgatory\Mapping\Loader\Configuration;
-use SofaScore\Purgatory\WebCache\WebCacheInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->parameters()
@@ -62,7 +61,7 @@ return static function (ContainerConfigurator $container) {
         ->args([
             ref('router'),
             ref('sofascore.purgatory.cache_refresh'),
-            ref(WebCacheInterface::class),
+            ref('sofascore.purgatory.purger'),
         ])
         ->tag('doctrine.event_listener', ['event' => 'preRemove'])
         ->tag('doctrine.event_listener', ['event' => 'postPersist'])

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -60,10 +60,13 @@ return static function (ContainerConfigurator $container) {
 
         ->set('sofascore.purgatory.cache_refresh.entity_change_listener', EntityChangeListener::class)
         ->args([
-            ref('doctrine.dbal.event_manager'),
-            ref('sofascore.purgatory.cache_refresh'),
             ref('router'),
+            ref('sofascore.purgatory.cache_refresh'),
             ref(WebCacheInterface::class),
         ])
+        ->tag('doctrine.event_listener', ['event' => 'preRemove'])
+        ->tag('doctrine.event_listener', ['event' => 'postPersist'])
+        ->tag('doctrine.event_listener', ['event' => 'postUpdate'])
+        ->tag('doctrine.event_listener', ['event' => 'postFlush'])
     ;
 };

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -57,7 +57,7 @@ return static function (ContainerConfigurator $container) {
             ref('property_accessor'),
         ])
 
-        ->set('sofascore.purgatory.cache_refresh.entity_change_listener', EntityChangeListener::class)
+        ->set('sofascore.purgatory.entity_change_listener', EntityChangeListener::class)
         ->args([
             ref('router'),
             ref('sofascore.purgatory.cache_refresh'),

--- a/WebCache/WebCacheInterface.php
+++ b/WebCache/WebCacheInterface.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace SofaScore\Purgatory\WebCache;
-
-interface WebCacheInterface
-{
-    public function enqueueUrlRefresh(string $url);
-}

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,7 +12,7 @@
         <directory name="DependencyInjection" />
         <directory name="Listener" />
         <directory name="Mapping" />
-        <directory name="WebCache" />
+        <directory name="Purger" />
         <file name="CacheRefresh.php" />
         <file name="PurgatoryBundle.php" />
         <ignoreFiles>


### PR DESCRIPTION
# Changes

- [x] `EntityChangeListener` is now implemented as a standard Symfony event listener (by leveraging the `DoctrineBundle` integration)
    - The listener can be optionally disabled via the `entity_change_listener` configuration node
- [x] Cache directory has been renamed to `purgatory`
- [x] It's now possible to configure the purger implementation via the `purger` configuration node
- [x] `WebCacheInterface` interface has been streamlined into the `PurgerInterface` interface