### PR TITLE
Validate route params during compilation

### DIFF
--- a/src/Cache/Subscription/PurgeSubscriptionProvider.php
+++ b/src/Cache/Subscription/PurgeSubscriptionProvider.php
@@ -110,7 +110,7 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
     /**
      * Check if all required route params are present in PurgeOn.
      *
-     * @var non-empty-array<string>
+     * @param non-empty-list<string> $routeParams
      */
     private function validateRouteParams(array $routeParams, RouteMetadata $routeMetadata): void
     {
@@ -126,7 +126,7 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
         if ([] !== $missingRouteParams = array_diff($requiredRouteParams, $routeParams)) {
             throw new MissingRequiredRouteParametersException(
                 routeName: $routeMetadata->routeName,
-                missingRouteParams: $missingRouteParams,
+                missingRouteParams: array_values($missingRouteParams),
             );
         }
     }

--- a/src/Exception/MissingRequiredRouteParametersException.php
+++ b/src/Exception/MissingRequiredRouteParametersException.php
@@ -16,7 +16,7 @@ final class MissingRequiredRouteParametersException extends \LogicException impl
         public readonly array $missingRouteParams,
     ) {
         parent::__construct(
-            \sprintf(self::MESSAGE, $this->routeName, implode(', ', $this->missingRouteParams)),
+            \sprintf(self::MESSAGE, $this->routeName, implode('", "', $this->missingRouteParams)),
         );
     }
 }

--- a/src/Exception/MissingRequiredRouteParametersException.php
+++ b/src/Exception/MissingRequiredRouteParametersException.php
@@ -6,7 +6,7 @@ namespace Sofascore\PurgatoryBundle\Exception;
 
 final class MissingRequiredRouteParametersException extends \LogicException implements PurgatoryException
 {
-    private const MESSAGE = 'Can not purge route "%s" because some required route parameters are missing (%s)';
+    private const MESSAGE = 'Cannot purge route "%s" because the following required route parameters are missing: "%s".';
 
     /**
      * @param non-empty-list<string> $missingRouteParams

--- a/src/Exception/MissingRequiredRouteParametersException.php
+++ b/src/Exception/MissingRequiredRouteParametersException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Exception;
+
+final class MissingRequiredRouteParametersException extends \LogicException implements PurgatoryException
+{
+    private const MESSAGE = 'Can not purge route "%s" because some required route parameters are missing (%s)';
+
+    /**
+     * @param non-empty-list<string> $missingRouteParams
+     */
+    public function __construct(
+        public readonly string $routeName,
+        public readonly array $missingRouteParams,
+    ) {
+        parent::__construct(
+            \sprintf(self::MESSAGE, $this->routeName, implode(', ', $this->missingRouteParams)),
+        );
+    }
+}

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -341,9 +341,9 @@ final class PurgeSubscriptionProviderTest extends TestCase
 
         $this->expectException(\LogicException::class);
 
-        $missingParams = implode(', ', $expectedMissingRequiredParameters);
+        $missingParams = implode('", "', $expectedMissingRequiredParameters);
         $this->expectExceptionMessage(
-            "Can not purge route \"foo\" because some required route parameters are missing ($missingParams)",
+            "Cannot purge route \"foo\" because the following required route parameters are missing: \"$missingParams\".",
         );
 
         [...$purgeSubscriptionProvider->provide()];

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -321,8 +321,8 @@ final class PurgeSubscriptionProviderTest extends TestCase
         [...$purgeSubscriptionProvider->provide()];
     }
 
-    #[DataProvider('provideRouteMetadataWithInvalidPurgeRouteParams')]
-    public function testInvalidRouteParams(
+    #[DataProvider('provideRouteMetadataWithMissingPurgeRouteParams')]
+    public function testWithMissingRouteParams(
         RouteMetadata $routeMetadata,
         array $expectedMissingRequiredParameters,
     ): void {
@@ -349,7 +349,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
         [...$purgeSubscriptionProvider->provide()];
     }
 
-    public static function provideRouteMetadataWithInvalidPurgeRouteParams(): iterable
+    public static function provideRouteMetadataWithMissingPurgeRouteParams(): iterable
     {
         $route = new Route(
             path: '/{foo}',

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -320,4 +320,158 @@ final class PurgeSubscriptionProviderTest extends TestCase
 
         [...$purgeSubscriptionProvider->provide()];
     }
+
+    #[DataProvider('provideRouteMetadataWithInvalidPurgeRouteParams')]
+    public function testInvalidRouteParams(
+        RouteMetadata $routeMetadata,
+        array $expectedMissingRequiredParameters,
+    ): void {
+        $routeMetadataProvider = $this->createMock(RouteMetadataProviderInterface::class);
+        $routeMetadataProvider->method('provide')
+            ->willReturnCallback(function () use ($routeMetadata) {
+                yield $routeMetadata;
+            });
+
+        $purgeSubscriptionProvider = new PurgeSubscriptionProvider(
+            subscriptionResolvers: [],
+            routeMetadataProviders: [$routeMetadataProvider],
+            managerRegistry: $this->createMock(ManagerRegistry::class),
+            targetResolverLocator: $this->createMock(ContainerInterface::class),
+        );
+
+        $this->expectException(\LogicException::class);
+
+        $missingParams = implode(', ', $expectedMissingRequiredParameters);
+        $this->expectExceptionMessage(
+            "Can not purge route \"foo\" because some required route parameters are missing ($missingParams)",
+        );
+
+        [...$purgeSubscriptionProvider->provide()];
+    }
+
+    public static function provideRouteMetadataWithInvalidPurgeRouteParams(): iterable
+    {
+        $route = new Route(
+            path: '/{foo}',
+            defaults: [],
+        );
+        yield [
+            'routeMetadata' => new RouteMetadata(
+                routeName: 'foo',
+                route: $route,
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    routeParams: [
+                        'bar' => 'bar',
+                    ],
+                ),
+                reflectionMethod: null,
+            ),
+            'expectedMissingRequiredParameters' => ['foo'],
+        ];
+
+        $route = new Route(
+            path: '/{foo}/{bar}',
+            defaults: [
+                'bar' => 'bar',
+            ],
+        );
+        yield [
+            'routeMetadata' => new RouteMetadata(
+                routeName: 'foo',
+                route: $route,
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    routeParams: [
+                        'bar' => 'bar',
+                    ],
+                ),
+                reflectionMethod: null,
+            ),
+            'expectedMissingRequiredParameters' => ['foo'],
+        ];
+
+        $route = new Route(
+            path: '/{foo}/{bar}/{baz}',
+            defaults: [
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ],
+        );
+        yield [
+            'routeMetadata' => new RouteMetadata(
+                routeName: 'foo',
+                route: $route,
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    routeParams: [
+                        'baz' => 'baz',
+                    ],
+                ),
+                reflectionMethod: null,
+            ),
+            'expectedMissingRequiredParameters' => ['foo'],
+        ];
+
+        $route = new Route(
+            path: '/{foo}/{bar}/{baz}',
+            defaults: [
+                'baz' => 'baz',
+            ],
+        );
+        yield [
+            'routeMetadata' => new RouteMetadata(
+                routeName: 'foo',
+                route: $route,
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    routeParams: [
+                        'foo' => 'foo',
+                    ],
+                ),
+                reflectionMethod: null,
+            ),
+            'expectedMissingRequiredParameters' => ['bar'],
+        ];
+
+        $route = new Route(
+            path: '/{foo}/{bar}/{baz}',
+            defaults: [
+                'baz' => 'baz',
+            ],
+        );
+        yield [
+            'routeMetadata' => new RouteMetadata(
+                routeName: 'foo',
+                route: $route,
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    routeParams: [
+                        'qux' => 'qux',
+                    ],
+                ),
+                reflectionMethod: null,
+            ),
+            'expectedMissingRequiredParameters' => ['foo', 'bar'],
+        ];
+
+        $route = new Route(
+            path: '/{foo}/{bar}/{baz}',
+            defaults: [],
+        );
+        yield [
+            'routeMetadata' => new RouteMetadata(
+                routeName: 'foo',
+                route: $route,
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    routeParams: [
+                        'bar' => 'bar',
+                    ],
+                ),
+                reflectionMethod: null,
+            ),
+            'expectedMissingRequiredParameters' => ['foo', 'baz'],
+        ];
+    }
 }


### PR DESCRIPTION
Currently if we have invalid PurgeOn with missing route params like this:

```php
#[Route('/{foo}/{bar}')]
#[PurgeOn(Entity:class, routeParams: ['bar' => 'bar'])]
```

When this PurgeOn is triggered, `MissingMandatoryParametersException` will be thrown with message 
`Some mandatory parameters are missing ("foo", "bar") to generate a URL for route "foo".`

Because of this exception, transaction will be rollbacked and all changes are lost.
We can detect these invalid PurgeOns during cache warmup when they are parsed.