### PR TITLE
Validate `if` expression during cache warmup

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -73,6 +73,7 @@ return static function (ContainerConfigurator $container) {
                 tagged_iterator('purgatory.route_metadata_provider'),
                 service('doctrine'),
                 tagged_locator('purgatory.target_resolver', defaultIndexMethod: 'for'),
+                service('sofascore.purgatory.expression_language')->nullOnInvalid(),
             ])
 
         ->set('sofascore.purgatory.subscription_resolver.property', PropertyResolver::class)

--- a/src/Cache/Subscription/PurgeSubscriptionProvider.php
+++ b/src/Cache/Subscription/PurgeSubscriptionProvider.php
@@ -140,12 +140,12 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
         }
     }
 
-    private function validateIfExpression(Expression $expression, string $route): void
+    private function validateIfExpression(Expression $expression, string $routeName): void
     {
         try {
             $this->expressionLanguage?->lint($expression, ['obj']);
         } catch (SyntaxError $e) {
-            throw new InvalidIfExpressionException($expression, $route, $e);
+            throw new InvalidIfExpressionException($expression, $routeName, $e);
         }
     }
 }

--- a/src/Cache/Subscription/PurgeSubscriptionProvider.php
+++ b/src/Cache/Subscription/PurgeSubscriptionProvider.php
@@ -14,8 +14,12 @@ use Sofascore\PurgatoryBundle\Cache\RouteMetadata\RouteMetadata;
 use Sofascore\PurgatoryBundle\Cache\RouteMetadata\RouteMetadataProviderInterface;
 use Sofascore\PurgatoryBundle\Cache\TargetResolver\TargetResolverInterface;
 use Sofascore\PurgatoryBundle\Exception\EntityMetadataNotFoundException;
+use Sofascore\PurgatoryBundle\Exception\InvalidIfExpressionException;
 use Sofascore\PurgatoryBundle\Exception\MissingRequiredRouteParametersException;
 use Sofascore\PurgatoryBundle\Exception\TargetSubscriptionNotResolvableException;
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 /**
  * @internal Used during cache warmup
@@ -31,6 +35,7 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
         private readonly iterable $routeMetadataProviders,
         private readonly ManagerRegistry $managerRegistry,
         private readonly ContainerInterface $targetResolverLocator,
+        private readonly ?ExpressionLanguage $expressionLanguage,
     ) {
     }
 
@@ -51,6 +56,10 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
     {
         foreach ($routeMetadataProvider->provide() as $routeMetadata) {
             $purgeOn = $routeMetadata->purgeOn;
+
+            if (null !== $purgeOn->if) {
+                $this->validateIfExpression($purgeOn->if);
+            }
 
             // if route parameters are not specified, they are same as path variables
             if (null === $purgeOn->routeParams) {
@@ -128,6 +137,15 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
                 routeName: $routeMetadata->routeName,
                 missingRouteParams: array_values($missingRouteParams),
             );
+        }
+    }
+
+    private function validateIfExpression(Expression $expression): void
+    {
+        try {
+            $this->expressionLanguage?->lint($expression, ['obj']);
+        } catch (SyntaxError $e) {
+            throw new InvalidIfExpressionException($expression, $e);
         }
     }
 }

--- a/src/Cache/Subscription/PurgeSubscriptionProvider.php
+++ b/src/Cache/Subscription/PurgeSubscriptionProvider.php
@@ -58,7 +58,7 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
             $purgeOn = $routeMetadata->purgeOn;
 
             if (null !== $purgeOn->if) {
-                $this->validateIfExpression($purgeOn->if);
+                $this->validateIfExpression($purgeOn->if, $routeMetadata->routeName);
             }
 
             // if route parameters are not specified, they are same as path variables
@@ -140,12 +140,12 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
         }
     }
 
-    private function validateIfExpression(Expression $expression): void
+    private function validateIfExpression(Expression $expression, string $route): void
     {
         try {
             $this->expressionLanguage?->lint($expression, ['obj']);
         } catch (SyntaxError $e) {
-            throw new InvalidIfExpressionException($expression, $e);
+            throw new InvalidIfExpressionException($expression, $route, $e);
         }
     }
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\Exception;
 
-final class InvalidArgumentException extends \InvalidArgumentException implements PurgatoryException
+class InvalidArgumentException extends \InvalidArgumentException implements PurgatoryException
 {
 }

--- a/src/Exception/InvalidIfExpressionException.php
+++ b/src/Exception/InvalidIfExpressionException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Exception;
+
+use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\SyntaxError;
+
+final class InvalidIfExpressionException extends RuntimeException
+{
+    private const MESSAGE = 'Invalid "if" expression: "%s"';
+
+    public function __construct(Expression $expression, SyntaxError $syntaxError)
+    {
+        parent::__construct(
+            message: \sprintf(self::MESSAGE, $expression),
+            previous: $syntaxError,
+        );
+    }
+}

--- a/src/Exception/InvalidIfExpressionException.php
+++ b/src/Exception/InvalidIfExpressionException.php
@@ -13,11 +13,11 @@ final class InvalidIfExpressionException extends InvalidArgumentException
 
     public function __construct(
         public readonly Expression $expression,
-        public readonly string $route,
+        public readonly string $routeName,
         SyntaxError $syntaxError,
     ) {
         parent::__construct(
-            message: \sprintf(self::MESSAGE, $route, $syntaxError->getMessage()),
+            message: \sprintf(self::MESSAGE, $routeName, $syntaxError->getMessage()),
             previous: $syntaxError,
         );
     }

--- a/src/Exception/InvalidIfExpressionException.php
+++ b/src/Exception/InvalidIfExpressionException.php
@@ -9,14 +9,15 @@ use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 final class InvalidIfExpressionException extends InvalidArgumentException
 {
-    private const MESSAGE = 'Invalid "if" expression provided: "%s"';
+    private const MESSAGE = 'Invalid "if" expression provided for route "%s": "%s"';
 
     public function __construct(
         public readonly Expression $expression,
+        public readonly string $route,
         SyntaxError $syntaxError,
     ) {
         parent::__construct(
-            message: \sprintf(self::MESSAGE, $syntaxError->getMessage()),
+            message: \sprintf(self::MESSAGE, $route, $syntaxError->getMessage()),
             previous: $syntaxError,
         );
     }

--- a/src/Exception/InvalidIfExpressionException.php
+++ b/src/Exception/InvalidIfExpressionException.php
@@ -7,14 +7,16 @@ namespace Sofascore\PurgatoryBundle\Exception;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
 
-final class InvalidIfExpressionException extends RuntimeException
+final class InvalidIfExpressionException extends InvalidArgumentException
 {
-    private const MESSAGE = 'Invalid "if" expression: "%s"';
+    private const MESSAGE = 'Invalid "if" expression provided: "%s"';
 
-    public function __construct(Expression $expression, SyntaxError $syntaxError)
-    {
+    public function __construct(
+        public readonly Expression $expression,
+        SyntaxError $syntaxError,
+    ) {
         parent::__construct(
-            message: \sprintf(self::MESSAGE, $expression),
+            message: \sprintf(self::MESSAGE, $syntaxError->getMessage()),
             previous: $syntaxError,
         );
     }

--- a/tests/Application/ConfigurationTest.php
+++ b/tests/Application/ConfigurationTest.php
@@ -33,7 +33,7 @@ final class ConfigurationTest extends AbstractKernelTestCase
     {
         parent::setUpBeforeClass();
 
-        self::initializeApplication(['test_case' => 'TestApplication']);
+        self::initializeApplication(['test_case' => 'TestApplication', 'config' => 'app_config.yaml']);
 
         self::$configuration = self::getContainer()->get('sofascore.purgatory.configuration_loader')->load();
 

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -364,7 +364,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
     #[TestWith(['entity !== null'])]
     #[TestWith(['some_function(obj)'])]
     #[TestWith(['valid_function(author)'])]
-    public function testInvalidIfExpression(string $invalidIf): void
+    public function testExceptionIsThrownOnInvalidIfExpression(string $invalidIf): void
     {
         $routeMetadataProvider = $this->createMock(RouteMetadataProviderInterface::class);
         $routeMetadataProvider->method('provide')

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Sofascore\PurgatoryBundle\Attribute\PurgeOn;
@@ -21,8 +22,12 @@ use Sofascore\PurgatoryBundle\Cache\Subscription\PurgeSubscription;
 use Sofascore\PurgatoryBundle\Cache\Subscription\PurgeSubscriptionProvider;
 use Sofascore\PurgatoryBundle\Cache\TargetResolver\TargetResolverInterface;
 use Sofascore\PurgatoryBundle\Exception\EntityMetadataNotFoundException;
+use Sofascore\PurgatoryBundle\Exception\InvalidIfExpressionException;
 use Sofascore\PurgatoryBundle\Tests\Cache\Subscription\Fixtures\DummyController;
 use Sofascore\PurgatoryBundle\Tests\Cache\Subscription\Fixtures\DummyTarget;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Routing\Route;
 
 #[CoversClass(PurgeSubscriptionProvider::class)]
@@ -45,6 +50,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $this->createMock(ManagerRegistry::class),
             targetResolverLocator: $targetResolverLocator,
+            expressionLanguage: new ExpressionLanguage(),
         );
 
         /** @var PurgeSubscription[] $propertySubscriptions */
@@ -174,6 +180,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $managerRegistry,
             targetResolverLocator: $targetResolverLocator,
+            expressionLanguage: new ExpressionLanguage(),
         );
 
         /** @var PurgeSubscription[] $propertySubscriptions */
@@ -315,6 +322,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $managerRegistry,
             targetResolverLocator: $this->createMock(ContainerInterface::class),
+            expressionLanguage: new ExpressionLanguage(),
         );
 
         $this->expectException(EntityMetadataNotFoundException::class);
@@ -339,6 +347,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $this->createMock(ManagerRegistry::class),
             targetResolverLocator: $this->createMock(ContainerInterface::class),
+            expressionLanguage: new ExpressionLanguage(),
         );
 
         $this->expectException(\LogicException::class);
@@ -347,6 +356,51 @@ final class PurgeSubscriptionProviderTest extends TestCase
         $this->expectExceptionMessage(
             "Cannot purge route \"foo\" because the following required route parameters are missing: \"$missingParams\".",
         );
+
+        [...$purgeSubscriptionProvider->provide()];
+    }
+
+    #[TestWith(['invalidObj.getMethod()'])]
+    #[TestWith(['entity !== null'])]
+    #[TestWith(['some_function(obj)'])]
+    #[TestWith(['valid_function(author)'])]
+    public function testInvalidIfExpression(string $invalidIf): void
+    {
+        $routeMetadataProvider = $this->createMock(RouteMetadataProviderInterface::class);
+        $routeMetadataProvider->method('provide')
+            ->willReturnCallback(function () use ($invalidIf): iterable {
+                yield new RouteMetadata(
+                    routeName: 'foo',
+                    route: new Route('/{foo}'),
+                    purgeOn: new PurgeOn(
+                        class: 'FooEntity',
+                        if: $invalidIf,
+                    ),
+                    reflectionMethod: null,
+                );
+            });
+
+        $purgeSubscriptionProvider = new PurgeSubscriptionProvider(
+            subscriptionResolvers: [],
+            routeMetadataProviders: [$routeMetadataProvider],
+            managerRegistry: $this->createMock(ManagerRegistry::class),
+            targetResolverLocator: $this->createMock(ContainerInterface::class),
+            expressionLanguage: new ExpressionLanguage(
+                providers: [
+                    new class implements ExpressionFunctionProviderInterface {
+                        public function getFunctions(): array
+                        {
+                            return [
+                                new ExpressionFunction('valid_function', function () {}, function () {}),
+                            ];
+                        }
+                    },
+                ],
+            ),
+        );
+
+        $this->expectException(InvalidIfExpressionException::class);
+        $this->expectExceptionMessage("Invalid \"if\" expression: \"$invalidIf\"");
 
         [...$purgeSubscriptionProvider->provide()];
     }

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -362,19 +362,19 @@ final class PurgeSubscriptionProviderTest extends TestCase
 
     #[TestWith([
         'if' => 'invalidObj.getMethod()',
-        'expectedMessage' => 'Invalid "if" expression provided: "Variable "invalidObj" is not valid around position 1 for expression `invalidObj.getMethod()`."',
+        'expectedMessage' => 'Invalid "if" expression provided for route "foo": "Variable "invalidObj" is not valid around position 1 for expression `invalidObj.getMethod()`."',
     ])]
     #[TestWith([
         'if' => 'entity !== null',
-        'expectedMessage' => 'Invalid "if" expression provided: "Variable "entity" is not valid around position 1 for expression `entity !== null`."',
+        'expectedMessage' => 'Invalid "if" expression provided for route "foo": "Variable "entity" is not valid around position 1 for expression `entity !== null`."',
     ])]
     #[TestWith([
         'if' => 'some_function(obj)',
-        'expectedMessage' => 'Invalid "if" expression provided: "The function "some_function" does not exist around position 1 for expression `some_function(obj)`."',
+        'expectedMessage' => 'Invalid "if" expression provided for route "foo": "The function "some_function" does not exist around position 1 for expression `some_function(obj)`."',
     ])]
     #[TestWith([
         'if' => 'valid_function(author)',
-        'expectedMessage' => 'Invalid "if" expression provided: "Variable "author" is not valid around position 16 for expression `valid_function(author)`."',
+        'expectedMessage' => 'Invalid "if" expression provided for route "foo": "Variable "author" is not valid around position 16 for expression `valid_function(author)`."',
     ])]
     public function testExceptionIsThrownOnInvalidIfExpression(string $if, string $expectedMessage): void
     {

--- a/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
+++ b/tests/Cache/Subscription/PurgeSubscriptionProviderTest.php
@@ -50,7 +50,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $this->createMock(ManagerRegistry::class),
             targetResolverLocator: $targetResolverLocator,
-            expressionLanguage: new ExpressionLanguage(),
+            expressionLanguage: null,
         );
 
         /** @var PurgeSubscription[] $propertySubscriptions */
@@ -180,7 +180,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $managerRegistry,
             targetResolverLocator: $targetResolverLocator,
-            expressionLanguage: new ExpressionLanguage(),
+            expressionLanguage: null,
         );
 
         /** @var PurgeSubscription[] $propertySubscriptions */
@@ -322,7 +322,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $managerRegistry,
             targetResolverLocator: $this->createMock(ContainerInterface::class),
-            expressionLanguage: new ExpressionLanguage(),
+            expressionLanguage: null,
         );
 
         $this->expectException(EntityMetadataNotFoundException::class);
@@ -347,7 +347,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
             routeMetadataProviders: [$routeMetadataProvider],
             managerRegistry: $this->createMock(ManagerRegistry::class),
             targetResolverLocator: $this->createMock(ContainerInterface::class),
-            expressionLanguage: new ExpressionLanguage(),
+            expressionLanguage: null,
         );
 
         $this->expectException(\LogicException::class);
@@ -360,21 +360,33 @@ final class PurgeSubscriptionProviderTest extends TestCase
         [...$purgeSubscriptionProvider->provide()];
     }
 
-    #[TestWith(['invalidObj.getMethod()'])]
-    #[TestWith(['entity !== null'])]
-    #[TestWith(['some_function(obj)'])]
-    #[TestWith(['valid_function(author)'])]
-    public function testExceptionIsThrownOnInvalidIfExpression(string $invalidIf): void
+    #[TestWith([
+        'if' => 'invalidObj.getMethod()',
+        'expectedMessage' => 'Invalid "if" expression provided: "Variable "invalidObj" is not valid around position 1 for expression `invalidObj.getMethod()`."',
+    ])]
+    #[TestWith([
+        'if' => 'entity !== null',
+        'expectedMessage' => 'Invalid "if" expression provided: "Variable "entity" is not valid around position 1 for expression `entity !== null`."',
+    ])]
+    #[TestWith([
+        'if' => 'some_function(obj)',
+        'expectedMessage' => 'Invalid "if" expression provided: "The function "some_function" does not exist around position 1 for expression `some_function(obj)`."',
+    ])]
+    #[TestWith([
+        'if' => 'valid_function(author)',
+        'expectedMessage' => 'Invalid "if" expression provided: "Variable "author" is not valid around position 16 for expression `valid_function(author)`."',
+    ])]
+    public function testExceptionIsThrownOnInvalidIfExpression(string $if, string $expectedMessage): void
     {
         $routeMetadataProvider = $this->createMock(RouteMetadataProviderInterface::class);
         $routeMetadataProvider->method('provide')
-            ->willReturnCallback(function () use ($invalidIf): iterable {
+            ->willReturnCallback(function () use ($if): iterable {
                 yield new RouteMetadata(
                     routeName: 'foo',
                     route: new Route('/{foo}'),
                     purgeOn: new PurgeOn(
                         class: 'FooEntity',
-                        if: $invalidIf,
+                        if: $if,
                     ),
                     reflectionMethod: null,
                 );
@@ -400,7 +412,7 @@ final class PurgeSubscriptionProviderTest extends TestCase
         );
 
         $this->expectException(InvalidIfExpressionException::class);
-        $this->expectExceptionMessage("Invalid \"if\" expression: \"$invalidIf\"");
+        $this->expectExceptionMessage($expectedMessage);
 
         [...$purgeSubscriptionProvider->provide()];
     }


### PR DESCRIPTION
Currently, if there is an error in the `PurgeOn::if` expression (e.g., an invalid variable or a call to a non-existent function), the exception is only thrown at runtime when the subscription is being processed.
Some errors can be detected earlier (during cache warmup) using `ExpressionLanguage::lint`