### PR TITLE
Generate inverse 'if' expression from Expression AST

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -93,6 +93,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('purgatory.subscription_resolver')
             ->args([
                 service('property_info.reflection_extractor'),
+                service('sofascore.purgatory.expression_language')->nullOnInvalid(),
             ])
 
         ->set('sofascore.purgatory.subscription_resolver.embeddable', EmbeddableResolver::class)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.3.0@222dda8483516044c2ed7a4c3f197d7c9d6c3ddb">
+<files psalm-version="6.10.1@f9fd6bc117e9ce1e854c2ed6777e7135aaa4966b">
   <file src="src/Cache/Configuration/CachedConfigurationLoader.php">
     <MixedArgument>
       <code><![CDATA[require $cache->getPath()]]></code>
@@ -7,6 +7,44 @@
     <UnresolvableInclude>
       <code><![CDATA[require $cache->getPath()]]></code>
     </UnresolvableInclude>
+  </file>
+  <file src="src/Cache/PropertyResolver/AssociationResolver.php">
+    <InternalClass>
+      <code><![CDATA[GetAttrNode::METHOD_CALL]]></code>
+      <code><![CDATA[GetAttrNode::PROPERTY_CALL]]></code>
+      <code><![CDATA[new ArgumentsNode()]]></code>
+      <code><![CDATA[new ConstantNode(
+                    value: $inverse,
+                    isIdentifier: true,
+                )]]></code>
+      <code><![CDATA[new GetAttrNode(
+                node: new NameNode('obj'),
+                attribute: new ConstantNode(
+                    value: $inverse,
+                    isIdentifier: true,
+                ),
+                arguments: new ArgumentsNode(),
+                type: $type,
+            )]]></code>
+      <code><![CDATA[new NameNode('obj')]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code><![CDATA[new ArgumentsNode()]]></code>
+      <code><![CDATA[new ConstantNode(
+                    value: $inverse,
+                    isIdentifier: true,
+                )]]></code>
+      <code><![CDATA[new GetAttrNode(
+                node: new NameNode('obj'),
+                attribute: new ConstantNode(
+                    value: $inverse,
+                    isIdentifier: true,
+                ),
+                arguments: new ArgumentsNode(),
+                type: $type,
+            )]]></code>
+      <code><![CDATA[new NameNode('obj')]]></code>
+    </InternalMethod>
   </file>
   <file src="src/Cache/RouteMetadata/AttributeMetadataProvider.php">
     <PossiblyUndefinedArrayOffset>

--- a/src/Cache/PropertyResolver/AssociationResolver.php
+++ b/src/Cache/PropertyResolver/AssociationResolver.php
@@ -12,6 +12,7 @@ use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\InverseValuesAwareInterf
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\ValuesInterface;
 use Sofascore\PurgatoryBundle\Cache\RouteMetadata\RouteMetadata;
 use Sofascore\PurgatoryBundle\Cache\Subscription\PurgeSubscription;
+use Sofascore\PurgatoryBundle\Exception\LogicException;
 use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
@@ -118,10 +119,7 @@ final class AssociationResolver implements SubscriptionResolverInterface
             PropertyReadInfo::TYPE_PROPERTY => [GetAttrNode::PROPERTY_CALL, $name],
         };
 
-        if (null === $node = $this->expressionLanguage?->parse($expression, ['obj'])->getNodes()) {
-            throw new \RuntimeException('Could not parse expression: '.(string) $expression);
-        }
-
+        $node = $this->getExpressionLanguage()->parse($expression, ['obj'])->getNodes();
         $inverseIf = $this->replaceObjWithInverse($node, $name, $callType)->dump();
 
         return new Expression("obj.$getter !== null && ($inverseIf)");
@@ -156,5 +154,11 @@ final class AssociationResolver implements SubscriptionResolverInterface
         }
 
         return $newNode;
+    }
+
+    private function getExpressionLanguage(): ExpressionLanguage
+    {
+        return $this->expressionLanguage
+            ?? throw new LogicException('You cannot use expressions because the Symfony ExpressionLanguage component is not installed. Try running "composer require symfony/expression-language".');
     }
 }

--- a/src/Cache/PropertyResolver/AssociationResolver.php
+++ b/src/Cache/PropertyResolver/AssociationResolver.php
@@ -14,6 +14,12 @@ use Sofascore\PurgatoryBundle\Cache\RouteMetadata\RouteMetadata;
 use Sofascore\PurgatoryBundle\Cache\Subscription\PurgeSubscription;
 use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\Node\ArgumentsNode;
+use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+use Symfony\Component\ExpressionLanguage\Node\GetAttrNode;
+use Symfony\Component\ExpressionLanguage\Node\NameNode;
+use Symfony\Component\ExpressionLanguage\Node\Node;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 
@@ -21,6 +27,7 @@ final class AssociationResolver implements SubscriptionResolverInterface
 {
     public function __construct(
         private readonly PropertyReadInfoExtractorInterface $extractor,
+        private readonly ?ExpressionLanguage $expressionLanguage,
     ) {
     }
 
@@ -72,10 +79,7 @@ final class AssociationResolver implements SubscriptionResolverInterface
         }
 
         if (null !== $if = $routeMetadata->purgeOn->if) {
-            $expression = (string) $if;
-            $getter = $this->createGetter($associationClass, $associationTarget);
-            $inverseIf = str_replace('obj', 'obj.'.$getter, $expression);
-            $if = new Expression("obj.$getter !== null && ($inverseIf)");
+            $if = $this->createInverseExpression($if, $associationClass, $associationTarget);
         }
 
         yield new PurgeSubscription(
@@ -96,18 +100,55 @@ final class AssociationResolver implements SubscriptionResolverInterface
         return $values instanceof InverseValuesAwareInterface ? $values->buildInverseValuesFor($associationTarget) : $values;
     }
 
-    private function createGetter(string $class, string $property): string
-    {
-        if (null === $readInfo = $this->extractor->getReadInfo($class, $property)) {
-            throw new PropertyNotAccessibleException($class, $property);
+    private function createInverseExpression(
+        Expression $expression,
+        string $associationClass,
+        string $associationTarget,
+    ): Expression {
+        if (null === $readInfo = $this->extractor->getReadInfo($associationClass, $associationTarget)) {
+            throw new PropertyNotAccessibleException($associationClass, $associationTarget);
         }
 
         /** @var PropertyReadInfo::TYPE_* $type */
         $type = $readInfo->getType();
+        $name = $readInfo->getName();
 
-        return match ($type) {
-            PropertyReadInfo::TYPE_METHOD => $readInfo->getName().'()',
-            PropertyReadInfo::TYPE_PROPERTY => $readInfo->getName(),
+        [$callType, $getter] = match ($type) {
+            PropertyReadInfo::TYPE_METHOD => [GetAttrNode::METHOD_CALL, "$name()"],
+            PropertyReadInfo::TYPE_PROPERTY => [GetAttrNode::PROPERTY_CALL, $name],
         };
+
+        if (null === $node = $this->expressionLanguage?->parse($expression, ['obj'])->getNodes()) {
+            throw new \RuntimeException('Could not parse expression: '.$expression);
+        }
+
+        $inverseIf = $this->replaceObjWithInverse($node, $name, $callType)->dump();
+
+        return new Expression("obj.$getter !== null && ($inverseIf)");
+    }
+
+    private function replaceObjWithInverse(Node $node, string $inverse, int $type): Node
+    {
+        if ($node instanceof NameNode && 'obj' === $node->attributes['name']) {
+            return new GetAttrNode(
+                node: new NameNode('obj'),
+                attribute: new ConstantNode(
+                    value: $inverse,
+                    isIdentifier: true,
+                    isNullSafe: false,
+                ),
+                arguments: new ArgumentsNode(),
+                type: $type,
+            );
+        }
+
+        $newNode = clone $node;
+        $newNode->nodes = [];
+
+        foreach ($node->nodes as $key => $childNode) {
+            $newNode->nodes[$key] = $this->replaceObjWithInverse($childNode, $inverse, $type);
+        }
+
+        return $newNode;
     }
 }

--- a/src/Cache/PropertyResolver/AssociationResolver.php
+++ b/src/Cache/PropertyResolver/AssociationResolver.php
@@ -119,7 +119,7 @@ final class AssociationResolver implements SubscriptionResolverInterface
         };
 
         if (null === $node = $this->expressionLanguage?->parse($expression, ['obj'])->getNodes()) {
-            throw new \RuntimeException('Could not parse expression: '.$expression);
+            throw new \RuntimeException('Could not parse expression: '. (string) $expression);
         }
 
         $inverseIf = $this->replaceObjWithInverse($node, $name, $callType)->dump();
@@ -127,6 +127,9 @@ final class AssociationResolver implements SubscriptionResolverInterface
         return new Expression("obj.$getter !== null && ($inverseIf)");
     }
 
+    /**
+     * @param GetAttrNode::PROPERTY_CALL|GetAttrNode::METHOD_CALL $type
+     */
     private function replaceObjWithInverse(Node $node, string $inverse, int $type): Node
     {
         if ($node instanceof NameNode && 'obj' === $node->attributes['name']) {
@@ -145,6 +148,10 @@ final class AssociationResolver implements SubscriptionResolverInterface
         $newNode = clone $node;
         $newNode->nodes = [];
 
+        /**
+         * @var string $key
+         * @var Node $childNode
+         */
         foreach ($node->nodes as $key => $childNode) {
             $newNode->nodes[$key] = $this->replaceObjWithInverse($childNode, $inverse, $type);
         }

--- a/src/Cache/PropertyResolver/AssociationResolver.php
+++ b/src/Cache/PropertyResolver/AssociationResolver.php
@@ -119,7 +119,7 @@ final class AssociationResolver implements SubscriptionResolverInterface
         };
 
         if (null === $node = $this->expressionLanguage?->parse($expression, ['obj'])->getNodes()) {
-            throw new \RuntimeException('Could not parse expression: '. (string) $expression);
+            throw new \RuntimeException('Could not parse expression: '.(string) $expression);
         }
 
         $inverseIf = $this->replaceObjWithInverse($node, $name, $callType)->dump();
@@ -138,7 +138,6 @@ final class AssociationResolver implements SubscriptionResolverInterface
                 attribute: new ConstantNode(
                     value: $inverse,
                     isIdentifier: true,
-                    isNullSafe: false,
                 ),
                 arguments: new ArgumentsNode(),
                 type: $type,
@@ -150,7 +149,7 @@ final class AssociationResolver implements SubscriptionResolverInterface
 
         /**
          * @var string $key
-         * @var Node $childNode
+         * @var Node   $childNode
          */
         foreach ($node->nodes as $key => $childNode) {
             $newNode->nodes[$key] = $this->replaceObjWithInverse($childNode, $inverse, $type);

--- a/tests/Application/ConfigurationTest.php
+++ b/tests/Application/ConfigurationTest.php
@@ -257,7 +257,7 @@ final class ConfigurationTest extends AbstractKernelTestCase
                         ],
                     ],
                 ],
-                'if' => "obj.owner !== null && (obj.owner.firstName === 'John')",
+                'if' => 'obj.owner !== null && ((obj.owner.firstName === "John"))',
             ],
         ];
     }

--- a/tests/Cache/PropertyResolver/AssociationResolverTestCase.php
+++ b/tests/Cache/PropertyResolver/AssociationResolverTestCase.php
@@ -220,7 +220,6 @@ abstract class AssociationResolverTestCase extends TestCase
             ->with('fooProperty')
             ->willReturn($isAssociationInverseSide);
 
-
         if ($isGetAssociationMappedByTargetFieldCalled) {
             $classMetadata->expects(self::once())
                 ->method('getAssociationMappedByTargetField')
@@ -254,7 +253,7 @@ abstract class AssociationResolverTestCase extends TestCase
         );
 
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage("Unable to create a getter for property \"BarEntity::barProperty\".");
+        $this->expectExceptionMessage('Unable to create a getter for property "BarEntity::barProperty".');
 
         [...$purgeSubscription];
     }

--- a/tests/Cache/PropertyResolver/AssociationResolverTestCase.php
+++ b/tests/Cache/PropertyResolver/AssociationResolverTestCase.php
@@ -14,6 +14,7 @@ use Sofascore\PurgatoryBundle\Attribute\Target\ForProperties;
 use Sofascore\PurgatoryBundle\Cache\PropertyResolver\AssociationResolver;
 use Sofascore\PurgatoryBundle\Cache\RouteMetadata\RouteMetadata;
 use Sofascore\PurgatoryBundle\Cache\Subscription\PurgeSubscription;
+use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Kernel;
@@ -188,4 +189,73 @@ abstract class AssociationResolverTestCase extends TestCase
     }
 
     abstract public static function invalidAssociationProvider(): iterable;
+
+    #[DataProvider('associationProvider')]
+    public function testExceptionIsThrownOnUnreadableAssocationTarget(
+        array $associationMapping,
+        bool $isGetAssociationMappedByTargetFieldCalled,
+        bool $isAssociationInverseSide,
+    ): void {
+        $extractor = $this->createMock(PropertyReadInfoExtractorInterface::class);
+        $extractor->expects(self::once())
+            ->method('getReadInfo')
+            ->with('BarEntity', 'barProperty')
+            ->willReturn(null);
+
+        $resolver = new AssociationResolver(
+            extractor: $extractor,
+            expressionLanguage: new ExpressionLanguage(),
+        );
+
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata->expects(self::once())
+            ->method('hasAssociation')
+            ->with('fooProperty')
+            ->willReturn(true);
+        $classMetadata->method('getAssociationMapping')
+            ->with('fooProperty')
+            ->willReturn($this->createAssociationMapping($associationMapping));
+
+        $classMetadata->method('isAssociationInverseSide')
+            ->with('fooProperty')
+            ->willReturn($isAssociationInverseSide);
+
+
+        if ($isGetAssociationMappedByTargetFieldCalled) {
+            $classMetadata->expects(self::once())
+                ->method('getAssociationMappedByTargetField')
+                ->with('fooProperty')
+                ->willReturn('barProperty');
+        } else {
+            $classMetadata->expects(self::never())
+                ->method('getAssociationMappedByTargetField');
+        }
+
+        $classMetadata->method('getAssociationTargetClass')
+            ->with('fooProperty')
+            ->willReturn('BarEntity');
+
+        $purgeSubscription = $resolver->resolveSubscription(
+            routeMetadata: new RouteMetadata(
+                routeName: 'route_foo',
+                route: new Route('/foo/{param1}/{param2}'),
+                purgeOn: new PurgeOn(
+                    class: 'FooEntity',
+                    if: new Expression('obj.isActive() === true'),
+                ),
+                reflectionMethod: null,
+            ),
+            classMetadata: $classMetadata,
+            routeParams: [
+                'param1' => new PropertyValues('bazProperty'),
+                'param2' => new RawValues('const'),
+            ],
+            target: 'fooProperty',
+        );
+
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage("Unable to create a getter for property \"BarEntity::barProperty\".");
+
+        [...$purgeSubscription];
+    }
 }

--- a/tests/Cache/PropertyResolver/AssociationResolverTestCase.php
+++ b/tests/Cache/PropertyResolver/AssociationResolverTestCase.php
@@ -15,6 +15,7 @@ use Sofascore\PurgatoryBundle\Cache\PropertyResolver\AssociationResolver;
 use Sofascore\PurgatoryBundle\Cache\RouteMetadata\RouteMetadata;
 use Sofascore\PurgatoryBundle\Cache\Subscription\PurgeSubscription;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
@@ -43,7 +44,10 @@ abstract class AssociationResolverTestCase extends TestCase
                 ),
             );
 
-        $resolver = new AssociationResolver($extractor);
+        $resolver = new AssociationResolver(
+            extractor: $extractor,
+            expressionLanguage: new ExpressionLanguage(),
+        );
 
         $classMetadata = $this->createMock(ClassMetadata::class);
         $classMetadata->method('hasAssociation')
@@ -104,7 +108,7 @@ abstract class AssociationResolverTestCase extends TestCase
             $subscription[0]->routeParams['param1'],
         );
         self::assertEquals(new RawValues('const'), $subscription[0]->routeParams['param2']);
-        self::assertSame('obj.getFoo() !== null && (obj.getFoo().isActive() === true)', (string) $subscription[0]->if);
+        self::assertSame('obj.getFoo() !== null && ((obj.getFoo().isActive() === true))', (string) $subscription[0]->if);
     }
 
     abstract public static function associationProvider(): iterable;
@@ -112,7 +116,8 @@ abstract class AssociationResolverTestCase extends TestCase
     public function testFieldNotAssociation(): void
     {
         $resolver = new AssociationResolver(
-            $this->createMock(PropertyReadInfoExtractorInterface::class),
+            extractor: $this->createMock(PropertyReadInfoExtractorInterface::class),
+            expressionLanguage: new ExpressionLanguage(),
         );
 
         $classMetadata = $this->createMock(ClassMetadata::class);
@@ -146,7 +151,8 @@ abstract class AssociationResolverTestCase extends TestCase
     public function testInvalidAssociationType(array $associationMapping): void
     {
         $resolver = new AssociationResolver(
-            $this->createMock(PropertyReadInfoExtractorInterface::class),
+            extractor: $this->createMock(PropertyReadInfoExtractorInterface::class),
+            expressionLanguage: new ExpressionLanguage(),
         );
 
         $classMetadata = $this->createMock(ClassMetadata::class);


### PR DESCRIPTION
Currently, we are using `str_replace` for generating inverse `PurgeOn::if` expressions. This can lead to invalid expressions if e.g. method name contains `obj` (`'obj.getobj()'`).

To avoid this, expression syntax tree is traversed so we can correctly detect where `obj` is called.