### PR TITLE
[Maker] Add make:purgatory-provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "symfony/expression-language": "^5.4 || ^6.4 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-client": "^5.4 || ^6.4 || ^7.0",
+        "symfony/maker-bundle": "^1.62",
         "symfony/messenger": "^5.4 || ^6.4 || ^7.0",
         "symfony/process": "^5.4 || ^6.4 || ^7.0",
         "symfony/serializer": "^5.4 || ^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "symfony/expression-language": "^5.4 || ^6.4 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-client": "^5.4 || ^6.4 || ^7.0",
-        "symfony/maker-bundle": "^1.33",
+        "symfony/maker-bundle": "^1.62",
         "symfony/messenger": "^5.4 || ^6.4 || ^7.0",
         "symfony/process": "^5.4 || ^6.4 || ^7.0",
         "symfony/serializer": "^5.4 || ^6.4 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "symfony/expression-language": "^5.4 || ^6.4 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-client": "^5.4 || ^6.4 || ^7.0",
-        "symfony/maker-bundle": "^1.62",
+        "symfony/maker-bundle": "^1.33",
         "symfony/messenger": "^5.4 || ^6.4 || ^7.0",
         "symfony/process": "^5.4 || ^6.4 || ^7.0",
         "symfony/serializer": "^5.4 || ^6.4 || ^7.0",

--- a/config/services.php
+++ b/config/services.php
@@ -18,6 +18,7 @@ use Sofascore\PurgatoryBundle\Cache\TargetResolver\ForPropertiesResolver;
 use Sofascore\PurgatoryBundle\Command\DebugCommand;
 use Sofascore\PurgatoryBundle\Doctrine\DBAL\Middleware;
 use Sofascore\PurgatoryBundle\Listener\EntityChangeListener;
+use Sofascore\PurgatoryBundle\Maker\MakeRouteProvider;
 use Sofascore\PurgatoryBundle\Purger\AsyncPurger;
 use Sofascore\PurgatoryBundle\Purger\InMemoryPurger;
 use Sofascore\PurgatoryBundle\Purger\Messenger\PurgeMessageHandler;
@@ -234,5 +235,11 @@ return static function (ContainerConfigurator $container) {
                 service('doctrine'),
             ])
             ->tag('console.command')
+
+        ->set('sofascore.purgatory.maker.make_provider', MakeRouteProvider::class)
+        ->args([
+            service('doctrine'),
+        ])
+        ->tag('maker.command')
     ;
 };

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.3.0@222dda8483516044c2ed7a4c3f197d7c9d6c3ddb">
+<files psalm-version="6.10.1@f9fd6bc117e9ce1e854c2ed6777e7135aaa4966b">
   <file src="src/Cache/Configuration/CachedConfigurationLoader.php">
     <MixedArgument>
       <code><![CDATA[require $cache->getPath()]]></code>
@@ -84,5 +84,32 @@
     <DuplicateClass>
       <code><![CDATA[PurgatoryConnection]]></code>
     </DuplicateClass>
+  </file>
+  <file src="src/Maker/MakeRouteProvider.php">
+    <InternalClass>
+      <code><![CDATA[ClassData::create(
+            class: \sprintf('Purgatory\RouteProvider\%s', $name),
+            suffix: 'RouteProvider',
+            useStatements: [
+                RouteProviderInterface::class,
+                PurgeRoute::class,
+                Action::class,
+                $entity,
+            ],
+        )]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code><![CDATA[ClassData::create(
+            class: \sprintf('Purgatory\RouteProvider\%s', $name),
+            suffix: 'RouteProvider',
+            useStatements: [
+                RouteProviderInterface::class,
+                PurgeRoute::class,
+                Action::class,
+                $entity,
+            ],
+        )]]></code>
+      <code><![CDATA[generateClassFromClassData]]></code>
+    </InternalMethod>
   </file>
 </files>

--- a/src/Maker/MakeRouteProvider.php
+++ b/src/Maker/MakeRouteProvider.php
@@ -61,7 +61,8 @@ final class MakeRouteProvider extends AbstractMaker
      */
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
-        $name = (string) $input->getArgument('name');
+        /** @var string $name */
+        $name = $input->getArgument('name');
 
         if (false === $entity = $this->inputEntity($io)) {
             return;
@@ -102,7 +103,9 @@ final class MakeRouteProvider extends AbstractMaker
     {
         $q = new Question('What entity is the purge route provider for?');
         $q->setTrimmable(true);
-        $purgeEntity = (string) $io->askQuestion($q);
+
+        /** @var string $purgeEntity */
+        $purgeEntity = $io->askQuestion($q);
 
         $entities = $this->getEntityCollection();
         $entities = array_filter(

--- a/src/Maker/MakeRouteProvider.php
+++ b/src/Maker/MakeRouteProvider.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Maker;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Sofascore\PurgatoryBundle\Listener\Enum\Action;
+use Sofascore\PurgatoryBundle\Maker\Util\ActionCollection;
+use Sofascore\PurgatoryBundle\RouteProvider\PurgeRoute;
+use Sofascore\PurgatoryBundle\RouteProvider\RouteProviderInterface;
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Bundle\MakerBundle\Util\ClassSource\Model\ClassData;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+
+final class MakeRouteProvider extends AbstractMaker
+{
+    public function __construct(
+        private readonly ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getCommandName(): string
+    {
+        return 'make:purgatory-provider';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command->addArgument('name', InputArgument::OPTIONAL, 'The name of the Purgatory route provider class (e.g. <fg=yellow>BlogPostRouteProvider</>)');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $name = (string) $input->getArgument('name');
+
+        if (false === $entity = $this->inputEntity($io)) {
+            return;
+        }
+
+        $variables = [
+            'entity' => Str::getShortClassName($entity),
+        ];
+
+        if (null !== $actions = $this->inputActions($io)) {
+            $variables['actions'] = new ActionCollection($actions);
+        }
+
+        $classData = ClassData::create(
+            class: \sprintf('Purgatory\RouteProvider\%s', $name),
+            suffix: 'RouteProvider',
+            useStatements: [
+                RouteProviderInterface::class,
+                PurgeRoute::class,
+                Action::class,
+                $entity,
+            ],
+        );
+
+        $generator->generateClassFromClassData(
+            classData: $classData,
+            templateName: __DIR__.'/../../templates/maker/RouteProvider.tpl.php',
+            variables: $variables,
+        );
+
+        $generator->writeChanges();
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'TODO';
+    }
+
+    /**
+     * @return class-string|false
+     */
+    private function inputEntity(ConsoleStyle $io): string|false
+    {
+        $q = new Question('What entity is the purge route provider for?');
+        $q->setTrimmable(true);
+        $purgeEntity = (string) $io->askQuestion($q);
+
+        $entities = $this->getEntityCollection();
+        $entities = array_filter(
+            $entities,
+            static fn (string $name): bool => str_contains(strtolower($name), strtolower($purgeEntity)),
+            \ARRAY_FILTER_USE_KEY,
+        );
+
+        if ([] === $entities) {
+            $io->error('No entities found');
+
+            return false;
+        }
+
+        if (1 === \count($entities) && 1 === \count($entities[array_key_first($entities)])) {
+            $entity = $entities[array_key_first($entities)][0];
+        } else {
+            $entityChoices = array_keys($entities);
+            sort($entityChoices, \SORT_STRING | \SORT_FLAG_CASE);
+
+            /** @var string $target */
+            $target = $io->choice('Select one of the available entities', $entityChoices);
+
+            /** @var class-string $entity */
+            $entity = \count($entities[$target]) > 1
+                ? $io->choice('Select one of the available entities', $entities[$target])
+                : $entities[$target][0];
+        }
+
+        return $entity;
+    }
+
+    /**
+     * @return ?non-empty-list<'Create'|'Update'|'Delete'>
+     */
+    private function inputActions(ConsoleStyle $io): ?array
+    {
+        if ($io->confirm('Should route provider handle only some actions (update/create/delete)?', default: false)) {
+            /** @var non-empty-list<'Create'|'Update'|'Delete'> $actions */
+            $actions = $io->choice(
+                question: 'Select actions',
+                choices: [
+                    Action::Create->name,
+                    Action::Update->name,
+                    Action::Delete->name,
+                ],
+                multiSelect: true,
+            );
+
+            $actions = array_values(array_unique($actions));
+        } else {
+            $actions = null;
+        }
+
+        return $actions;
+    }
+
+    /**
+     * @return array<string, non-empty-list<class-string>>
+     */
+    private function getEntityCollection(): array
+    {
+        /** @var array<string, non-empty-list<class-string>> $entities */
+        $entities = [];
+
+        foreach ($this->managerRegistry->getManagers() as $manager) {
+            foreach ($manager->getMetadataFactory()->getAllMetadata() as $metadata) {
+                $entityFqcn = $metadata->getName();
+                $name = strrchr($entityFqcn, '\\');
+                $name = substr(false === $name ? $entityFqcn : $name, 1);
+
+                if (isset($entities[$name])) {
+                    if (!\in_array($entityFqcn, $entities[$name], true)) {
+                        $entities[$name][] = $entityFqcn;
+                    }
+                } else {
+                    $entities[$name] = [$entityFqcn];
+                }
+            }
+        }
+
+        foreach ($entities as &$entityFqcns) {
+            sort($entityFqcns, \SORT_STRING | \SORT_FLAG_CASE);
+        }
+
+        return $entities;
+    }
+}

--- a/src/Maker/MakeRouteProvider.php
+++ b/src/Maker/MakeRouteProvider.php
@@ -36,6 +36,11 @@ final class MakeRouteProvider extends AbstractMaker
         return 'make:purgatory-provider';
     }
 
+    public static function getCommandDescription(): string
+    {
+        return 'Create a purge route provider';
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -88,11 +93,6 @@ final class MakeRouteProvider extends AbstractMaker
         );
 
         $generator->writeChanges();
-    }
-
-    public static function getCommandDescription(): string
-    {
-        return 'TODO';
     }
 
     /**

--- a/src/Maker/Util/ActionCollection.php
+++ b/src/Maker/Util/ActionCollection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Maker\Util;
+
+final class ActionCollection
+{
+    /**
+     * @param non-empty-list<'Create'|'Update'|'Delete'> $actions
+     */
+    public function __construct(
+        private readonly array $actions,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        if (1 === \count($this->actions)) {
+            return "Action::{$this->actions[0]} === \$action";
+        }
+
+        $haystack = implode(
+            ', ',
+            array_map(static fn (string $name): string => "Action::$name", $this->actions),
+        );
+
+        return "\in_array(\$action, [$haystack], true)";
+    }
+}

--- a/templates/maker/RouteProvider.tpl.php
+++ b/templates/maker/RouteProvider.tpl.php
@@ -1,13 +1,13 @@
-<?= "<?php\n" ?>
+<?php echo "<?php\n"; ?>
 
-namespace <?= $class_data->getNamespace(); ?>;
+namespace <?php echo $class_data->getNamespace(); ?>;
 
-<?= $class_data->getUseStatements() ?>
+<?php echo $class_data->getUseStatements(); ?>
 
 /**
- * @implements RouteProviderInterface<<?= $entity ?>>
+ * @implements RouteProviderInterface<<?php echo $entity; ?>>
  */
-<?= $class_data->getClassDeclaration() ?> implements RouteProviderInterface
+<?php echo $class_data->getClassDeclaration(); ?> implements RouteProviderInterface
 {
     /**
      * {@inheritDoc}
@@ -26,12 +26,12 @@ namespace <?= $class_data->getNamespace(); ?>;
 
     public function supports(Action $action, object $entity): bool
     {
-        return $entity instanceof <?= $entity?>
-<?php if (!isset($actions)): ?>
+        return $entity instanceof <?php echo $entity; ?>
+<?php if (!isset($actions)) { ?>
 ;
-<?php else: ?>
+<?php } else { ?>
 
-            && <?= $actions ?>;
-<?php endif ?>
+            && <?php echo $actions; ?>;
+<?php } ?>
     }
 }

--- a/templates/maker/RouteProvider.tpl.php
+++ b/templates/maker/RouteProvider.tpl.php
@@ -1,0 +1,37 @@
+<?= "<?php\n" ?>
+
+namespace <?= $class_data->getNamespace(); ?>;
+
+<?= $class_data->getUseStatements() ?>
+
+/**
+ * @implements RouteProviderInterface<<?= $entity ?>>
+ */
+<?= $class_data->getClassDeclaration() ?> implements RouteProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function provideRoutesFor(Action $action, object $entity, array $entityChangeSet): iterable
+    {
+        // add with your own logic if needed
+
+        yield new PurgeRoute(
+            name: 'app_route', // replace it with your route
+            params: [
+                'param1' => $entity, // replace it with correct data for route parameters
+            ],
+        );
+    }
+
+    public function supports(Action $action, object $entity): bool
+    {
+        return $entity instanceof <?= $entity?>
+<?php if (!isset($actions)): ?>
+;
+<?php else: ?>
+
+            && <?= $actions ?>;
+<?php endif ?>
+    }
+}

--- a/tests/Functional/TestApplication/config/app_config.yaml
+++ b/tests/Functional/TestApplication/config/app_config.yaml
@@ -5,3 +5,6 @@ services:
 
     Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\:
         resource: '../'
+
+maker:
+    root_namespace: 'Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Generated'

--- a/tests/Functional/TestKernel.php
+++ b/tests/Functional/TestKernel.php
@@ -7,6 +7,7 @@ namespace Sofascore\PurgatoryBundle\Tests\Functional;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Sofascore\PurgatoryBundle\PurgatoryBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -63,6 +64,7 @@ final class TestKernel extends Kernel
         yield new FrameworkBundle();
         yield new DoctrineBundle();
         yield new PurgatoryBundle();
+        yield new MakerBundle();
     }
 
     public function shutdown(): void

--- a/tests/Maker/Expected/AnimalCompetitionRouteProvider.txt
+++ b/tests/Maker/Expected/AnimalCompetitionRouteProvider.txt
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Generated\Purgatory\RouteProvider;
+
+use Sofascore\PurgatoryBundle\Listener\Enum\Action;
+use Sofascore\PurgatoryBundle\RouteProvider\PurgeRoute;
+use Sofascore\PurgatoryBundle\RouteProvider\RouteProviderInterface;
+use Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Entity\Competition\AnimalCompetition;
+
+/**
+ * @implements RouteProviderInterface<AnimalCompetition>
+ */
+final class AnimalCompetitionRouteProvider implements RouteProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function provideRoutesFor(Action $action, object $entity, array $entityChangeSet): iterable
+    {
+        // add with your own logic if needed
+
+        yield new PurgeRoute(
+            name: 'app_route', // replace it with your route
+            params: [
+                'param1' => $entity, // replace it with correct data for route parameters
+            ],
+        );
+    }
+
+    public function supports(Action $action, object $entity): bool
+    {
+        return $entity instanceof AnimalCompetition
+            && \in_array($action, [Action::Create, Action::Update, Action::Delete], true);
+    }
+}

--- a/tests/Maker/Expected/PlaneRouteProvider.txt
+++ b/tests/Maker/Expected/PlaneRouteProvider.txt
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Generated\Purgatory\RouteProvider;
+
+use Sofascore\PurgatoryBundle\Listener\Enum\Action;
+use Sofascore\PurgatoryBundle\RouteProvider\PurgeRoute;
+use Sofascore\PurgatoryBundle\RouteProvider\RouteProviderInterface;
+use Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Entity\Plane;
+
+/**
+ * @implements RouteProviderInterface<Plane>
+ */
+final class PlaneRouteProvider implements RouteProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function provideRoutesFor(Action $action, object $entity, array $entityChangeSet): iterable
+    {
+        // add with your own logic if needed
+
+        yield new PurgeRoute(
+            name: 'app_route', // replace it with your route
+            params: [
+                'param1' => $entity, // replace it with correct data for route parameters
+            ],
+        );
+    }
+
+    public function supports(Action $action, object $entity): bool
+    {
+        return $entity instanceof Plane;
+    }
+}

--- a/tests/Maker/Expected/ShipBuildRouteProvider.txt
+++ b/tests/Maker/Expected/ShipBuildRouteProvider.txt
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Generated\Purgatory\RouteProvider;
+
+use Sofascore\PurgatoryBundle\Listener\Enum\Action;
+use Sofascore\PurgatoryBundle\RouteProvider\PurgeRoute;
+use Sofascore\PurgatoryBundle\RouteProvider\RouteProviderInterface;
+use Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Entity\Ship;
+
+/**
+ * @implements RouteProviderInterface<Ship>
+ */
+final class ShipBuildRouteProvider implements RouteProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function provideRoutesFor(Action $action, object $entity, array $entityChangeSet): iterable
+    {
+        // add with your own logic if needed
+
+        yield new PurgeRoute(
+            name: 'app_route', // replace it with your route
+            params: [
+                'param1' => $entity, // replace it with correct data for route parameters
+            ],
+        );
+    }
+
+    public function supports(Action $action, object $entity): bool
+    {
+        return $entity instanceof Ship
+            && Action::Create === $action;
+    }
+}

--- a/tests/Maker/Expected/VehicleFixRouteProvider.txt
+++ b/tests/Maker/Expected/VehicleFixRouteProvider.txt
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Generated\Purgatory\RouteProvider;
+
+use Sofascore\PurgatoryBundle\Listener\Enum\Action;
+use Sofascore\PurgatoryBundle\RouteProvider\PurgeRoute;
+use Sofascore\PurgatoryBundle\RouteProvider\RouteProviderInterface;
+use Sofascore\PurgatoryBundle\Tests\Functional\TestApplication\Entity\Vehicle;
+
+/**
+ * @implements RouteProviderInterface<Vehicle>
+ */
+final class VehicleFixRouteProvider implements RouteProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function provideRoutesFor(Action $action, object $entity, array $entityChangeSet): iterable
+    {
+        // add with your own logic if needed
+
+        yield new PurgeRoute(
+            name: 'app_route', // replace it with your route
+            params: [
+                'param1' => $entity, // replace it with correct data for route parameters
+            ],
+        );
+    }
+
+    public function supports(Action $action, object $entity): bool
+    {
+        return $entity instanceof Vehicle
+            && \in_array($action, [Action::Update, Action::Delete], true);
+    }
+}

--- a/tests/Maker/MakeRouteProviderTest.php
+++ b/tests/Maker/MakeRouteProviderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Tests\Maker;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use Sofascore\PurgatoryBundle\Maker\MakeRouteProvider;
+use Sofascore\PurgatoryBundle\Tests\Functional\AbstractKernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[CoversClass(MakeRouteProvider::class)]
+final class MakeRouteProviderTest extends AbstractKernelTestCase
+{
+    private string|false $colSize;
+    private CommandTester $command;
+
+    protected function setUp(): void
+    {
+        $this->colSize = getenv('COLUMNS');
+        putenv('COLUMNS=300');
+
+        self::initializeApplication(['test_case' => 'TestApplication', 'config' => 'app_config.yaml']);
+
+        $this->command = new CommandTester((new Application(self::$kernel))->find('make:purgatory-provider'));
+    }
+
+    protected function tearDown(): void
+    {
+        putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
+
+        unset(
+            $this->colSize,
+            $this->command,
+        );
+
+        (new Filesystem())->remove(__DIR__.'/../Functional/TestApplication/Generated/');
+
+        parent::tearDown();
+    }
+
+    #[TestWith([
+        'input' => ['PlaneRouteProvider', 'Plane', 'no'],
+        'expected' => 'PlaneRouteProvider',
+    ])]
+    #[TestWith([
+        'input' => ['Plane', 'Plane', 'no'],
+        'expected' => 'PlaneRouteProvider',
+    ])]
+    #[TestWith([
+        'input' => ['ShipBuild', 'Ship', 'yes', '0'],
+        'expected' => 'ShipBuildRouteProvider',
+    ])]
+    #[TestWith([
+        'input' => ['VehicleFix', 'Vehicle', 'yes', '1,2'],
+        'expected' => 'VehicleFixRouteProvider',
+    ])]
+    #[TestWith([
+        'input' => ['AnimalCompetition', 'Animal', '1', 'yes', '0,1,2'],
+        'expected' => 'AnimalCompetitionRouteProvider',
+    ])]
+    public function testGenerateRouteProvider(array $input, string $expected): void
+    {
+        $this->command->setInputs([implode(\PHP_EOL, $input).\PHP_EOL]);
+        $this->command->execute([], ['interactive' => true]);
+
+        self::assertFileExists(__DIR__."/../Functional/TestApplication/Generated/Purgatory/RouteProvider/$expected.php");
+        self::assertFileEquals(
+            expected: __DIR__."/Expected/$expected.txt",
+            actual: __DIR__."/../Functional/TestApplication/Generated/Purgatory/RouteProvider/$expected.php",
+        );
+    }
+}

--- a/tests/Maker/MakeRouteProviderTest.php
+++ b/tests/Maker/MakeRouteProviderTest.php
@@ -73,4 +73,13 @@ final class MakeRouteProviderTest extends AbstractKernelTestCase
             actual: __DIR__."/../Functional/TestApplication/Generated/Purgatory/RouteProvider/$expected.php",
         );
     }
+
+    public function testInvalidEntityInput(): void
+    {
+        $input = ['foo', 'BlogPost'];
+        $this->command->setInputs([implode(\PHP_EOL, $input).\PHP_EOL]);
+        $this->command->execute([], ['interactive' => true]);
+
+        self::assertStringContainsString('[ERROR] No entities found', $this->command->getDisplay());
+    }
 }

--- a/tests/Maker/Util/ActionCollectionTest.php
+++ b/tests/Maker/Util/ActionCollectionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Tests\Maker\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Sofascore\PurgatoryBundle\Maker\Util\ActionCollection;
+
+#[CoversClass(ActionCollection::class)]
+final class ActionCollectionTest extends TestCase
+{
+    #[TestWith(['Create', 'Action::Create === $action'])]
+    #[TestWith(['Update', 'Action::Update === $action'])]
+    #[TestWith(['Delete', 'Action::Delete === $action'])]
+    public function testSingleAction(string $actionName, string $expected): void
+    {
+        $collection = new ActionCollection([$actionName]);
+        self::assertSame($expected, (string) $collection);
+    }
+
+    #[TestWith([['Create', 'Update'], '\in_array($action, [Action::Create, Action::Update], true)'])]
+    #[TestWith([['Create', 'Update', 'Delete'], '\in_array($action, [Action::Create, Action::Update, Action::Delete], true)'])]
+    #[TestWith([['Delete', 'Create', 'Update'], '\in_array($action, [Action::Delete, Action::Create, Action::Update], true)'])]
+    public function testMultipleActions(array $actions, string $expected): void
+    {
+        $collection = new ActionCollection($actions);
+        self::assertSame($expected, (string) $collection);
+    }
+}


### PR DESCRIPTION
Optional dependency for symfony/maker-bundle is added.
Maker command for creating route provider is added.
Command asks for name, entity and optionally actions (create/update/delete) and generates php class.
Route name and params have to be manually added.