### PR TITLE
Throw when `if` expression returns non-boolean

### DIFF
--- a/src/Exception/InvalidIfExpressionResultException.php
+++ b/src/Exception/InvalidIfExpressionResultException.php
@@ -6,7 +6,7 @@ namespace Sofascore\PurgatoryBundle\Exception;
 
 final class InvalidIfExpressionResultException extends \TypeError implements PurgatoryException
 {
-    private const MESSAGE = 'Expected return value of "if" expression (%s) to be boolean, got %s';
+    private const MESSAGE = 'Expected return value of "if" expression (%s) to be boolean, got %s.';
 
     public function __construct(
         public readonly string $expression,

--- a/src/Exception/InvalidIfExpressionResultException.php
+++ b/src/Exception/InvalidIfExpressionResultException.php
@@ -12,6 +12,6 @@ final class InvalidIfExpressionResultException extends \TypeError implements Pur
         public readonly string $expression,
         public readonly mixed $result,
     ) {
-        parent::__construct(\sprintf(self::MESSAGE, $expression, \get_debug_type($result)));
+        parent::__construct(\sprintf(self::MESSAGE, $expression, get_debug_type($result)));
     }
 }

--- a/src/Exception/InvalidIfExpressionResultException.php
+++ b/src/Exception/InvalidIfExpressionResultException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\Exception;
 
-final class InvalidIfResultException extends RuntimeException
+final class InvalidIfExpressionResultException extends \TypeError implements PurgatoryException
 {
     private const MESSAGE = 'Expected return value of "if" expression (%s) to be boolean, got %s';
 
@@ -12,6 +12,6 @@ final class InvalidIfResultException extends RuntimeException
         public readonly string $expression,
         public readonly mixed $result,
     ) {
-        parent::__construct(\sprintf(self::MESSAGE, $expression, \gettype($result)));
+        parent::__construct(\sprintf(self::MESSAGE, $expression, \get_debug_type($result)));
     }
 }

--- a/src/Exception/InvalidIfResultException.php
+++ b/src/Exception/InvalidIfResultException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Exception;
+
+final class InvalidIfResultException extends RuntimeException
+{
+    private const MESSAGE = 'Expected return value of "if" expression (%s) to be boolean, got %s';
+
+    public function __construct(
+        public readonly string $expression,
+        public readonly mixed $result,
+    ) {
+        parent::__construct(\sprintf(self::MESSAGE, $expression, \gettype($result)));
+    }
+}

--- a/src/RouteProvider/AbstractEntityRouteProvider.php
+++ b/src/RouteProvider/AbstractEntityRouteProvider.php
@@ -8,7 +8,7 @@ use Psr\Container\ContainerInterface;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Configuration;
 use Sofascore\PurgatoryBundle\Cache\Configuration\ConfigurationLoaderInterface;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Subscriptions;
-use Sofascore\PurgatoryBundle\Exception\InvalidIfResultException;
+use Sofascore\PurgatoryBundle\Exception\InvalidIfExpressionResultException;
 use Sofascore\PurgatoryBundle\Exception\LogicException;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 use Sofascore\PurgatoryBundle\RouteParamValueResolver\ValuesResolverInterface;
@@ -75,7 +75,7 @@ abstract class AbstractEntityRouteProvider implements RouteProviderInterface
             if (isset($subscription['if'])) {
                 $result = $this->getExpressionLanguage()->evaluate($subscription['if'], ['obj' => $entity]);
                 if (!\is_bool($result)) {
-                    throw new InvalidIfResultException($subscription['if'], $result);
+                    throw new InvalidIfExpressionResultException($subscription['if'], $result);
                 }
 
                 if (!$result) {

--- a/src/RouteProvider/AbstractEntityRouteProvider.php
+++ b/src/RouteProvider/AbstractEntityRouteProvider.php
@@ -78,7 +78,7 @@ abstract class AbstractEntityRouteProvider implements RouteProviderInterface
                     throw new InvalidIfResultException($subscription['if'], $result);
                 }
 
-                if (false === $result) {
+                if (!$result) {
                     continue;
                 }
             }

--- a/src/RouteProvider/AbstractEntityRouteProvider.php
+++ b/src/RouteProvider/AbstractEntityRouteProvider.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Configuration;
 use Sofascore\PurgatoryBundle\Cache\Configuration\ConfigurationLoaderInterface;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Subscriptions;
+use Sofascore\PurgatoryBundle\Exception\InvalidIfResultException;
 use Sofascore\PurgatoryBundle\Exception\LogicException;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 use Sofascore\PurgatoryBundle\RouteParamValueResolver\ValuesResolverInterface;
@@ -71,8 +72,15 @@ abstract class AbstractEntityRouteProvider implements RouteProviderInterface
                 continue;
             }
 
-            if (isset($subscription['if']) && false === $this->getExpressionLanguage()->evaluate($subscription['if'], ['obj' => $entity])) {
-                continue;
+            if (isset($subscription['if'])) {
+                $result = $this->getExpressionLanguage()->evaluate($subscription['if'], ['obj' => $entity]);
+                if (!\is_bool($result)) {
+                    throw new InvalidIfResultException($subscription['if'], $result);
+                }
+
+                if (false === $result) {
+                    continue;
+                }
             }
 
             $routeParamConfigs = $subscription['routeParams'] ?? [];

--- a/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
+++ b/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
@@ -6,13 +6,16 @@ namespace Sofascore\PurgatoryBundle\Tests\RouteProvider;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\CompoundValues;
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\EnumValues;
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\PropertyValues;
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\RawValues;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Configuration;
 use Sofascore\PurgatoryBundle\Cache\Configuration\ConfigurationLoaderInterface;
+use Sofascore\PurgatoryBundle\Exception\InvalidIfResultException;
 use Sofascore\PurgatoryBundle\Exception\LogicException;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 use Sofascore\PurgatoryBundle\RouteParamValueResolver\CompoundValuesResolver;
@@ -27,6 +30,7 @@ use Sofascore\PurgatoryBundle\Tests\Fixtures\DummyStringEnum;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
 #[CoversClass(AbstractEntityRouteProvider::class)]
@@ -359,6 +363,43 @@ final class UpdatedEntityRouteProviderTest extends TestCase
         self::assertSame(['name' => 'foo_route', 'params' => ['foo' => 'case1']], (array) $routes[3]);
         self::assertSame(['name' => 'foo_route', 'params' => ['foo' => 'case2']], (array) $routes[4]);
         self::assertSame(['name' => 'foo_route', 'params' => ['foo' => 'case3']], (array) $routes[5]);
+    }
+
+    #[TestWith([null, 'Expected return value of "if" expression (obj.val) to be boolean, got NULL'])]
+    #[TestWith([1, 'Expected return value of "if" expression (obj.val) to be boolean, got integer'])]
+    #[TestWith([0.0, 'Expected return value of "if" expression (obj.val) to be boolean, got double'])]
+    #[TestWith(['false', 'Expected return value of "if" expression (obj.val) to be boolean, got string'])]
+    #[TestWith([[true], 'Expected return value of "if" expression (obj.val) to be boolean, got array'])]
+    #[TestWith([new \stdClass(), 'Expected return value of "if" expression (obj.val) to be boolean, got object'])]
+    public function testExceptionIsThrownOnInvalidIfReturnType(mixed $ifResult, string $expectedMessage): void
+    {
+        $configurationLoader = $this->createMock(ConfigurationLoaderInterface::class);
+        $configurationLoader->expects(self::once())
+            ->method('load')
+            ->willReturn(new Configuration([
+                'stdClass' => [
+                    [
+                        'routeName' => 'foo_route',
+                        'if' => 'obj.val',
+                    ],
+                ],
+            ]));
+
+        $expressionLanguage = $this->createMock(ExpressionLanguage::class);
+        $expressionLanguage->expects(self::once())
+            ->method('evaluate')
+            ->willReturn($ifResult);
+
+        $routeProvider = new UpdatedEntityRouteProvider(
+            configurationLoader: $configurationLoader,
+            expressionLanguage: $expressionLanguage,
+            routeParamValueResolverLocator: $this->createMock(ContainerInterface::class),
+            propertyAccessor: $this->createMock(PropertyAccessorInterface::class),
+        );
+
+        $this->expectException(InvalidIfResultException::class);
+        $this->expectExceptionMessage($expectedMessage);
+        [...$routeProvider->provideRoutesFor(Action::Update, new \stdClass(), [])];
     }
 
     private function createRouteProvider(array $configuration, bool $withExpressionLang): UpdatedEntityRouteProvider

--- a/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
+++ b/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
@@ -365,12 +365,12 @@ final class UpdatedEntityRouteProviderTest extends TestCase
         self::assertSame(['name' => 'foo_route', 'params' => ['foo' => 'case3']], (array) $routes[5]);
     }
 
-    #[TestWith([null, 'Expected return value of "if" expression (obj.val) to be boolean, got null'])]
-    #[TestWith([1, 'Expected return value of "if" expression (obj.val) to be boolean, got int'])]
-    #[TestWith([0.0, 'Expected return value of "if" expression (obj.val) to be boolean, got float'])]
-    #[TestWith(['false', 'Expected return value of "if" expression (obj.val) to be boolean, got string'])]
-    #[TestWith([[true], 'Expected return value of "if" expression (obj.val) to be boolean, got array'])]
-    #[TestWith([new \stdClass(), 'Expected return value of "if" expression (obj.val) to be boolean, got stdClass'])]
+    #[TestWith([null, 'Expected return value of "if" expression (obj.val) to be boolean, got null.'])]
+    #[TestWith([1, 'Expected return value of "if" expression (obj.val) to be boolean, got int.'])]
+    #[TestWith([0.0, 'Expected return value of "if" expression (obj.val) to be boolean, got float.'])]
+    #[TestWith(['false', 'Expected return value of "if" expression (obj.val) to be boolean, got string.'])]
+    #[TestWith([[true], 'Expected return value of "if" expression (obj.val) to be boolean, got array.'])]
+    #[TestWith([new \stdClass(), 'Expected return value of "if" expression (obj.val) to be boolean, got stdClass.'])]
     public function testExceptionIsThrownOnInvalidIfReturnType(mixed $ifResult, string $expectedMessage): void
     {
         $configurationLoader = $this->createMock(ConfigurationLoaderInterface::class);

--- a/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
+++ b/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
@@ -15,7 +15,7 @@ use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\PropertyValues;
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\RawValues;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Configuration;
 use Sofascore\PurgatoryBundle\Cache\Configuration\ConfigurationLoaderInterface;
-use Sofascore\PurgatoryBundle\Exception\InvalidIfResultException;
+use Sofascore\PurgatoryBundle\Exception\InvalidIfExpressionResultException;
 use Sofascore\PurgatoryBundle\Exception\LogicException;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 use Sofascore\PurgatoryBundle\RouteParamValueResolver\CompoundValuesResolver;
@@ -365,12 +365,12 @@ final class UpdatedEntityRouteProviderTest extends TestCase
         self::assertSame(['name' => 'foo_route', 'params' => ['foo' => 'case3']], (array) $routes[5]);
     }
 
-    #[TestWith([null, 'Expected return value of "if" expression (obj.val) to be boolean, got NULL'])]
-    #[TestWith([1, 'Expected return value of "if" expression (obj.val) to be boolean, got integer'])]
-    #[TestWith([0.0, 'Expected return value of "if" expression (obj.val) to be boolean, got double'])]
+    #[TestWith([null, 'Expected return value of "if" expression (obj.val) to be boolean, got null'])]
+    #[TestWith([1, 'Expected return value of "if" expression (obj.val) to be boolean, got int'])]
+    #[TestWith([0.0, 'Expected return value of "if" expression (obj.val) to be boolean, got float'])]
     #[TestWith(['false', 'Expected return value of "if" expression (obj.val) to be boolean, got string'])]
     #[TestWith([[true], 'Expected return value of "if" expression (obj.val) to be boolean, got array'])]
-    #[TestWith([new \stdClass(), 'Expected return value of "if" expression (obj.val) to be boolean, got object'])]
+    #[TestWith([new \stdClass(), 'Expected return value of "if" expression (obj.val) to be boolean, got stdClass'])]
     public function testExceptionIsThrownOnInvalidIfReturnType(mixed $ifResult, string $expectedMessage): void
     {
         $configurationLoader = $this->createMock(ConfigurationLoaderInterface::class);
@@ -397,7 +397,7 @@ final class UpdatedEntityRouteProviderTest extends TestCase
             propertyAccessor: $this->createMock(PropertyAccessorInterface::class),
         );
 
-        $this->expectException(InvalidIfResultException::class);
+        $this->expectException(InvalidIfExpressionResultException::class);
         $this->expectExceptionMessage($expectedMessage);
         [...$routeProvider->provideRoutesFor(Action::Update, new \stdClass(), [])];
     }


### PR DESCRIPTION
After evaluation `if` expression, we only check if the result is `false`. If it is, subscription is skipped.
This means that expression can return anything else (true, null, string, object,...) and subscription won't be skipped, which is a bug because expression should always return bool.
Exception is thrown if evaluated expression is not boolean.