### PR TITLE
Errors from Symfony's PropertyAccessor now result in Purgatory's PropertyNotAccessibleException

### DIFF
--- a/src/Exception/PropertyNotAccessibleException.php
+++ b/src/Exception/PropertyNotAccessibleException.php
@@ -11,7 +11,7 @@ final class PropertyNotAccessibleException extends RuntimeException
     public function __construct(
         public readonly string $class,
         public readonly string $property,
-        public readonly \Throwable $previous,
+        public readonly ?\Throwable $previous = null,
     ) {
         parent::__construct(
             message: \sprintf(self::MESSAGE, $class, $property),

--- a/src/Exception/PropertyNotAccessibleException.php
+++ b/src/Exception/PropertyNotAccessibleException.php
@@ -11,9 +11,11 @@ final class PropertyNotAccessibleException extends RuntimeException
     public function __construct(
         public readonly string $class,
         public readonly string $property,
+        public readonly \Throwable $previous,
     ) {
         parent::__construct(
             message: \sprintf(self::MESSAGE, $class, $property),
+            previous: $previous,
         );
     }
 }

--- a/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
+++ b/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
@@ -35,10 +35,11 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
         if (!str_contains((string) $propertyPath, self::DELIMITER)) {
             try {
                 return $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
-            } catch (\InvalidArgumentException|AccessException|UnexpectedTypeException) {
+            } catch (\InvalidArgumentException|AccessException|UnexpectedTypeException $exception) {
                 throw new PropertyNotAccessibleException(
                     \is_array($objectOrArray) ? 'array' : $objectOrArray::class,
                     (string) $propertyPath,
+                    $exception,
                 );
             }
         }
@@ -48,10 +49,11 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
 
         try {
             $collection = $this->propertyAccessor->getValue($objectOrArray, $propertyPathParts[0]);
-        } catch (\InvalidArgumentException|AccessException|UnexpectedTypeException) {
+        } catch (\InvalidArgumentException|AccessException|UnexpectedTypeException $exception) {
             throw new PropertyNotAccessibleException(
                 \is_array($objectOrArray) ? 'array' : $objectOrArray::class,
                 $propertyPathParts[0],
+                $exception,
             );
         }
 

--- a/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
+++ b/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\RouteProvider\PropertyAccess;
 
-use InvalidArgumentException;
 use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Sofascore\PurgatoryBundle\Exception\ValueNotIterableException;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
@@ -27,19 +26,19 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
     /**
      * @param object|array<array-key, mixed> $objectOrArray
      * @param string|PropertyPathInterface   $propertyPath
-     * 
+     *
      * @throws PropertyNotAccessibleException
      * @throws ValueNotIterableException
      */
     public function getValue($objectOrArray, $propertyPath): mixed
     {
         if (!str_contains((string) $propertyPath, self::DELIMITER)) {
-            try{
+            try {
                 return $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
-            } catch (InvalidArgumentException|AccessException|UnexpectedTypeException) {
+            } catch (\InvalidArgumentException|AccessException|UnexpectedTypeException) {
                 throw new PropertyNotAccessibleException(
-                    \is_array($objectOrArray) ? 'array' : $objectOrArray::class, 
-                    (string)$propertyPath
+                    \is_array($objectOrArray) ? 'array' : $objectOrArray::class,
+                    (string) $propertyPath,
                 );
             }
         }
@@ -47,12 +46,12 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
         /** @var array{0: string, 1: string} $propertyPathParts */
         $propertyPathParts = explode(separator: self::DELIMITER, string: (string) $propertyPath, limit: 2);
 
-        try{
+        try {
             $collection = $this->propertyAccessor->getValue($objectOrArray, $propertyPathParts[0]);
-        } catch (InvalidArgumentException|AccessException|UnexpectedTypeException) {
+        } catch (\InvalidArgumentException|AccessException|UnexpectedTypeException) {
             throw new PropertyNotAccessibleException(
-                \is_array($objectOrArray) ? 'array' : $objectOrArray::class, 
-                $propertyPathParts[0]
+                \is_array($objectOrArray) ? 'array' : $objectOrArray::class,
+                $propertyPathParts[0],
             );
         }
 

--- a/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
+++ b/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
@@ -37,7 +37,10 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
             try{
                 return $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
             } catch (InvalidArgumentException|AccessException|UnexpectedTypeException) {
-                throw new PropertyNotAccessibleException($objectOrArray::class, (string)$propertyPath);
+                throw new PropertyNotAccessibleException(
+                    \is_array($objectOrArray) ? 'array' : $objectOrArray::class, 
+                    (string)$propertyPath
+                );
             }
         }
 
@@ -47,7 +50,10 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
         try{
             $collection = $this->propertyAccessor->getValue($objectOrArray, $propertyPathParts[0]);
         } catch (InvalidArgumentException|AccessException|UnexpectedTypeException) {
-            throw new PropertyNotAccessibleException($objectOrArray::class, $propertyPathParts[0]);
+            throw new PropertyNotAccessibleException(
+                \is_array($objectOrArray) ? 'array' : $objectOrArray::class, 
+                $propertyPathParts[0]
+            );
         }
 
         if (!is_iterable($collection)) {

--- a/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
+++ b/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
@@ -78,6 +78,8 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
     /**
      * @param object|array<array-key, mixed> $objectOrArray
      * @param string|PropertyPathInterface   $propertyPath
+     *
+     * @param-out object|array<array-key, mixed> $objectOrArray
      */
     public function setValue(&$objectOrArray, $propertyPath, mixed $value): void
     {
@@ -107,7 +109,7 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
             $this->getValue($objectOrArray, $propertyPath);
 
             return true;
-        } catch (AccessException|UnexpectedTypeException) {
+        } catch (PropertyNotAccessibleException) {
             return false;
         }
     }

--- a/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
+++ b/src/RouteProvider/PropertyAccess/PurgatoryPropertyAccessor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\RouteProvider\PropertyAccess;
 
+use InvalidArgumentException;
+use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Sofascore\PurgatoryBundle\Exception\ValueNotIterableException;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
@@ -25,17 +27,28 @@ final class PurgatoryPropertyAccessor implements PropertyAccessorInterface
     /**
      * @param object|array<array-key, mixed> $objectOrArray
      * @param string|PropertyPathInterface   $propertyPath
+     * 
+     * @throws PropertyNotAccessibleException
+     * @throws ValueNotIterableException
      */
     public function getValue($objectOrArray, $propertyPath): mixed
     {
         if (!str_contains((string) $propertyPath, self::DELIMITER)) {
-            return $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
+            try{
+                return $this->propertyAccessor->getValue($objectOrArray, $propertyPath);
+            } catch (InvalidArgumentException|AccessException|UnexpectedTypeException) {
+                throw new PropertyNotAccessibleException($objectOrArray::class, (string)$propertyPath);
+            }
         }
 
         /** @var array{0: string, 1: string} $propertyPathParts */
         $propertyPathParts = explode(separator: self::DELIMITER, string: (string) $propertyPath, limit: 2);
 
-        $collection = $this->propertyAccessor->getValue($objectOrArray, $propertyPathParts[0]);
+        try{
+            $collection = $this->propertyAccessor->getValue($objectOrArray, $propertyPathParts[0]);
+        } catch (InvalidArgumentException|AccessException|UnexpectedTypeException) {
+            throw new PropertyNotAccessibleException($objectOrArray::class, $propertyPathParts[0]);
+        }
 
         if (!is_iterable($collection)) {
             throw new ValueNotIterableException($collection, $propertyPathParts[0]);

--- a/tests/RouteProvider/PropertyAccess/Fixtures/Foo.php
+++ b/tests/RouteProvider/PropertyAccess/Fixtures/Foo.php
@@ -11,6 +11,7 @@ class Foo
     public function __construct(
         public readonly int $id,
         public readonly Collection $children,
+        private readonly ?string $privateProperty = 'value',
     ) {
     }
 

--- a/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
+++ b/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
@@ -165,6 +165,26 @@ final class PurgatoryPropertyAccessorTest extends TestCase
         );
     }
 
+    public function testTraversablePropertyNotAccessible(): void
+    {
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage(
+            \sprintf(
+                'Unable to create a getter for property "%s::%s".',
+                Foo::class,
+                'privateProperty',
+            ),
+        );
+
+        $this->purgatoryPropertyAccessor->getValue(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([]),
+            ),
+            propertyPath: 'privateProperty[*].values',
+        );
+    }
+
     public function testTraversableChildPropertyNotAccessible(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
@@ -209,6 +229,26 @@ final class PurgatoryPropertyAccessorTest extends TestCase
                 children: new ArrayCollection([]),
             ),
             propertyPath: 'nonExistentProperty',
+        );
+    }
+
+    public function testTraversablePropertyNotExist(): void
+    {
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage(
+            \sprintf(
+                'Unable to create a getter for property "%s::%s".',
+                Foo::class,
+                'nonExistentProperty',
+            ),
+        );
+
+        $this->purgatoryPropertyAccessor->getValue(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([]),
+            ),
+            propertyPath: 'nonExistentProperty[*].values',
         );
     }
 

--- a/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
+++ b/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
@@ -153,6 +153,38 @@ final class PurgatoryPropertyAccessorTest extends TestCase
         ));
     }
 
+    public function testReadTraversableChildPropertyNotExist(): void
+    {
+        self::assertFalse($this->purgatoryPropertyAccessor->isReadable(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([
+                    new Foo(
+                        id: 1,
+                        children: new ArrayCollection([]),
+                    ),
+                ]),
+            ),
+            propertyPath: 'children[*].nonExistentProperty',
+        ));
+    }
+
+    public function testReadTraversableChildPropertyNotAccessible(): void
+    {
+        self::assertFalse($this->purgatoryPropertyAccessor->isReadable(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([
+                    new Foo(
+                        id: 1,
+                        children: new ArrayCollection([]),
+                    ),
+                ]),
+            ),
+            propertyPath: 'children[*].privateProperty',
+        ));
+    }
+
     public function testNotTraversable(): void
     {
         $this->expectException(ValueNotIterableException::class);

--- a/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
+++ b/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
@@ -149,9 +149,9 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     {
         $this->expectException(PropertyNotAccessibleException::class);
         $this->expectExceptionMessage(
-            sprintf(
-                'Unable to create a getter for property "%s::%s".', 
-                Foo::class, 
+            \sprintf(
+                'Unable to create a getter for property "%s::%s".',
+                Foo::class,
                 'privateProperty',
             ),
         );
@@ -169,9 +169,9 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     {
         $this->expectException(PropertyNotAccessibleException::class);
         $this->expectExceptionMessage(
-            sprintf(
-                'Unable to create a getter for property "%s::%s".', 
-                Foo::class, 
+            \sprintf(
+                'Unable to create a getter for property "%s::%s".',
+                Foo::class,
                 'privateProperty',
             ),
         );
@@ -185,7 +185,7 @@ final class PurgatoryPropertyAccessorTest extends TestCase
                             id: 1,
                             children: new ArrayCollection([]),
                         ),
-                    ]
+                    ],
                 ),
             ),
             propertyPath: 'children[*].privateProperty',
@@ -196,9 +196,9 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     {
         $this->expectException(PropertyNotAccessibleException::class);
         $this->expectExceptionMessage(
-            sprintf(
-                'Unable to create a getter for property "%s::%s".', 
-                Foo::class, 
+            \sprintf(
+                'Unable to create a getter for property "%s::%s".',
+                Foo::class,
                 'nonExistentProperty',
             ),
         );
@@ -216,9 +216,9 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     {
         $this->expectException(PropertyNotAccessibleException::class);
         $this->expectExceptionMessage(
-            sprintf(
-                'Unable to create a getter for property "%s::%s".', 
-                Foo::class, 
+            \sprintf(
+                'Unable to create a getter for property "%s::%s".',
+                Foo::class,
                 'nonExistentProperty',
             ),
         );
@@ -232,10 +232,10 @@ final class PurgatoryPropertyAccessorTest extends TestCase
                             id: 1,
                             children: new ArrayCollection([]),
                         ),
-                    ]
+                    ],
                 ),
             ),
             propertyPath: 'children[*].nonExistentProperty',
         );
-    }    
+    }
 }

--- a/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
+++ b/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
@@ -131,6 +131,28 @@ final class PurgatoryPropertyAccessorTest extends TestCase
         ];
     }
 
+    public function testReadPathPropertyNotExist(): void
+    {
+        self::assertFalse($this->purgatoryPropertyAccessor->isReadable(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([]),
+            ),
+            propertyPath: 'nonExistentProperty',
+        ));
+    }
+
+    public function testReadPathPropertyNotAccessible(): void
+    {
+        self::assertFalse($this->purgatoryPropertyAccessor->isReadable(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([]),
+            ),
+            propertyPath: 'privateProperty',
+        ));
+    }
+
     public function testNotTraversable(): void
     {
         $this->expectException(ValueNotIterableException::class);

--- a/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
+++ b/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Sofascore\PurgatoryBundle\Exception\ValueNotIterableException;
 use Sofascore\PurgatoryBundle\RouteProvider\PropertyAccess\PurgatoryPropertyAccessor;
 use Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo;
@@ -143,4 +144,98 @@ final class PurgatoryPropertyAccessorTest extends TestCase
             propertyPath: 'id[*].id',
         );
     }
+
+    public function testPropertyNotAccessible(): void
+    {
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Unable to create a getter for property "%s::%s".', 
+                Foo::class, 
+                'privateProperty',
+            ),
+        );
+
+        $this->purgatoryPropertyAccessor->getValue(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([]),
+            ),
+            propertyPath: 'privateProperty',
+        );
+    }
+
+    public function testTraversableChildPropertyNotAccessible(): void
+    {
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Unable to create a getter for property "%s::%s".', 
+                Foo::class, 
+                'privateProperty',
+            ),
+        );
+
+        $this->purgatoryPropertyAccessor->getValue(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection(
+                    [
+                        new Foo(
+                            id: 1,
+                            children: new ArrayCollection([]),
+                        ),
+                    ]
+                ),
+            ),
+            propertyPath: 'children[*].privateProperty',
+        );
+    }
+
+    public function testPropertyNotExist(): void
+    {
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Unable to create a getter for property "%s::%s".', 
+                Foo::class, 
+                'nonExistentProperty',
+            ),
+        );
+
+        $this->purgatoryPropertyAccessor->getValue(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection([]),
+            ),
+            propertyPath: 'nonExistentProperty',
+        );
+    }
+
+    public function testTraversableChildPropertyNotExist(): void
+    {
+        $this->expectException(PropertyNotAccessibleException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Unable to create a getter for property "%s::%s".', 
+                Foo::class, 
+                'nonExistentProperty',
+            ),
+        );
+
+        $this->purgatoryPropertyAccessor->getValue(
+            objectOrArray: new Foo(
+                id: 1,
+                children: new ArrayCollection(
+                    [
+                        new Foo(
+                            id: 1,
+                            children: new ArrayCollection([]),
+                        ),
+                    ]
+                ),
+            ),
+            propertyPath: 'children[*].nonExistentProperty',
+        );
+    }    
 }

--- a/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
+++ b/tests/RouteProvider/PropertyAccess/PurgatoryPropertyAccessorTest.php
@@ -12,6 +12,7 @@ use Sofascore\PurgatoryBundle\Exception\PropertyNotAccessibleException;
 use Sofascore\PurgatoryBundle\Exception\ValueNotIterableException;
 use Sofascore\PurgatoryBundle\RouteProvider\PropertyAccess\PurgatoryPropertyAccessor;
 use Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 #[CoversClass(PurgatoryPropertyAccessor::class)]
@@ -202,13 +203,13 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     public function testPropertyNotAccessible(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage(
-            \sprintf(
-                'Unable to create a getter for property "%s::%s".',
-                Foo::class,
-                'privateProperty',
+        $this->expectExceptionObject(new PropertyNotAccessibleException(
+            class: Foo::class,
+            property: 'privateProperty',
+            previous: new NoSuchPropertyException(
+                message: 'Can\'t get a way to read the property "privateProperty" in class "Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo".',
             ),
-        );
+        ));
 
         $this->purgatoryPropertyAccessor->getValue(
             objectOrArray: new Foo(
@@ -222,13 +223,13 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     public function testTraversablePropertyNotAccessible(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage(
-            \sprintf(
-                'Unable to create a getter for property "%s::%s".',
-                Foo::class,
-                'privateProperty',
+        $this->expectExceptionObject(new PropertyNotAccessibleException(
+            class: Foo::class,
+            property: 'privateProperty',
+            previous: new NoSuchPropertyException(
+                message: 'Can\'t get a way to read the property "privateProperty" in class "Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo".',
             ),
-        );
+        ));
 
         $this->purgatoryPropertyAccessor->getValue(
             objectOrArray: new Foo(
@@ -242,13 +243,13 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     public function testTraversableChildPropertyNotAccessible(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage(
-            \sprintf(
-                'Unable to create a getter for property "%s::%s".',
-                Foo::class,
-                'privateProperty',
+        $this->expectExceptionObject(new PropertyNotAccessibleException(
+            class: Foo::class,
+            property: 'privateProperty',
+            previous: new NoSuchPropertyException(
+                message: 'Can\'t get a way to read the property "privateProperty" in class "Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo".',
             ),
-        );
+        ));
 
         $this->purgatoryPropertyAccessor->getValue(
             objectOrArray: new Foo(
@@ -269,13 +270,13 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     public function testPropertyNotExist(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage(
-            \sprintf(
-                'Unable to create a getter for property "%s::%s".',
-                Foo::class,
-                'nonExistentProperty',
+        $this->expectExceptionObject(new PropertyNotAccessibleException(
+            class: Foo::class,
+            property: 'nonExistentProperty',
+            previous: new NoSuchPropertyException(
+                message: 'Can\'t get a way to read the property "nonExistentProperty" in class "Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo".',
             ),
-        );
+        ));
 
         $this->purgatoryPropertyAccessor->getValue(
             objectOrArray: new Foo(
@@ -289,13 +290,13 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     public function testTraversablePropertyNotExist(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage(
-            \sprintf(
-                'Unable to create a getter for property "%s::%s".',
-                Foo::class,
-                'nonExistentProperty',
+        $this->expectExceptionObject(new PropertyNotAccessibleException(
+            class: Foo::class,
+            property: 'nonExistentProperty',
+            previous: new NoSuchPropertyException(
+                message: 'Can\'t get a way to read the property "nonExistentProperty" in class "Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo".',
             ),
-        );
+        ));
 
         $this->purgatoryPropertyAccessor->getValue(
             objectOrArray: new Foo(
@@ -309,13 +310,13 @@ final class PurgatoryPropertyAccessorTest extends TestCase
     public function testTraversableChildPropertyNotExist(): void
     {
         $this->expectException(PropertyNotAccessibleException::class);
-        $this->expectExceptionMessage(
-            \sprintf(
-                'Unable to create a getter for property "%s::%s".',
-                Foo::class,
-                'nonExistentProperty',
+        $this->expectExceptionObject(new PropertyNotAccessibleException(
+            class: Foo::class,
+            property: 'nonExistentProperty',
+            previous: new NoSuchPropertyException(
+                message: 'Can\'t get a way to read the property "nonExistentProperty" in class "Sofascore\PurgatoryBundle\Tests\RouteProvider\PropertyAccess\Fixtures\Foo".',
             ),
-        );
+        ));
 
         $this->purgatoryPropertyAccessor->getValue(
             objectOrArray: new Foo(


### PR DESCRIPTION
When Symfony's `PropertyAccessor` fails to get a property value, whether due to an incorrect argument provided to the method, a non-existent property, or a property with insufficient visibility, one of exceptions will be thrown:
`InvalidArgumentException`, `AccessException`, `UnexpectedTypeException`

Since Symfony's `PropertyAccessor` is used by many other bundles, and often in projects codebase directly, seeing this exception in logs doesn't immediately indicate that error occurred in Purgatory.

To improve visibility and observability when these errors occur, we are re-throwing the PropertyAccessor's exception as `PropertyNotAccessibleException` which is specific to the Purgatory bundle.
