### PR TITLE
Route param values cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ExpressionValues` to enable resolution of route parameter values via expressions by @HypeMC
   in https://github.com/sofascore/purgatory-bundle/pull/112
 
+### Changed
+
+- Method `AbstractValues::toArray()` is now `final` by @Brajk19
+  in https://github.com/sofascore/purgatory-bundle/pull/130
+- Method `AbstractValues::getValues()` is now `protected` by @Brajk19
+  in https://github.com/sofascore/purgatory-bundle/pull/130
+- Rename second constructor argument in `DynamicValues` to `$propertyPath` by @Brajk19
+  in https://github.com/sofascore/purgatory-bundle/pull/130
+
 ### Removed
 
 - Symfony v5 support by @HypeMC in https://github.com/sofascore/purgatory-bundle/pull/128
 - `InverseValuesAwareInterface`, use dedicated builder services instead by @HypeMC
   in https://github.com/sofascore/purgatory-bundle/pull/123
+- `ValuesInterface::getValues()`, use public properties instead by @Brajk19
+  in https://github.com/sofascore/purgatory-bundle/pull/130
 
 ## [1.3.0] - 2025-12-15
 

--- a/src/Attribute/RouteParamValue/AbstractValues.php
+++ b/src/Attribute/RouteParamValue/AbstractValues.php
@@ -7,9 +7,14 @@ namespace Sofascore\PurgatoryBundle\Attribute\RouteParamValue;
 abstract class AbstractValues implements ValuesInterface
 {
     /**
+     * @return non-empty-list<?scalar>
+     */
+    abstract protected function getValues(): array;
+
+    /**
      * {@inheritDoc}
      */
-    public function toArray(): array
+    final public function toArray(): array
     {
         return [
             'type' => static::type(),

--- a/src/Attribute/RouteParamValue/CompoundValues.php
+++ b/src/Attribute/RouteParamValue/CompoundValues.php
@@ -7,12 +7,12 @@ namespace Sofascore\PurgatoryBundle\Attribute\RouteParamValue;
 use Sofascore\PurgatoryBundle\Attribute\PurgeOn;
 use Sofascore\PurgatoryBundle\Exception\InvalidArgumentException;
 
-final class CompoundValues extends AbstractValues
+final class CompoundValues implements ValuesInterface
 {
     /**
      * @var non-empty-list<ValuesInterface>
      */
-    private readonly array $values;
+    public readonly array $values;
 
     /**
      * @param string|non-empty-list<string>|ValuesInterface $value
@@ -36,14 +36,6 @@ final class CompoundValues extends AbstractValues
         }
 
         $this->values = $normalized;
-    }
-
-    /**
-     * @return list<ValuesInterface>
-     */
-    public function getValues(): array
-    {
-        return $this->values;
     }
 
     /**

--- a/src/Attribute/RouteParamValue/DynamicValues.php
+++ b/src/Attribute/RouteParamValue/DynamicValues.php
@@ -11,7 +11,7 @@ final class DynamicValues extends AbstractValues
      */
     public function __construct(
         public readonly string $alias,
-        public readonly ?string $arg = null,
+        public readonly ?string $propertyPath = null,
     ) {
     }
 
@@ -20,7 +20,7 @@ final class DynamicValues extends AbstractValues
      */
     protected function getValues(): array
     {
-        return [$this->alias, $this->arg];
+        return [$this->alias, $this->propertyPath];
     }
 
     public static function type(): string

--- a/src/Attribute/RouteParamValue/DynamicValues.php
+++ b/src/Attribute/RouteParamValue/DynamicValues.php
@@ -10,15 +10,15 @@ final class DynamicValues extends AbstractValues
      * @param string $alias Alias defined in {@see AsRouteParamService} attribute
      */
     public function __construct(
-        private readonly string $alias,
-        private readonly ?string $arg = null,
+        public readonly string $alias,
+        public readonly ?string $arg = null,
     ) {
     }
 
     /**
-     * @return list<?string>
+     * @return non-empty-list<?string>
      */
-    public function getValues(): array
+    protected function getValues(): array
     {
         return [$this->alias, $this->arg];
     }

--- a/src/Attribute/RouteParamValue/EnumValues.php
+++ b/src/Attribute/RouteParamValue/EnumValues.php
@@ -12,7 +12,7 @@ final class EnumValues extends AbstractValues
      * @param class-string<\BackedEnum> $enum
      */
     public function __construct(
-        private readonly string $enum,
+        public readonly string $enum,
     ) {
         if (!is_a($this->enum, \BackedEnum::class, true)) {
             throw new InvalidArgumentException('The argument must be a backed enum.');
@@ -20,9 +20,9 @@ final class EnumValues extends AbstractValues
     }
 
     /**
-     * @return list<class-string<\BackedEnum>>
+     * @return non-empty-list<class-string<\BackedEnum>>
      */
-    public function getValues(): array
+    protected function getValues(): array
     {
         return [$this->enum];
     }

--- a/src/Attribute/RouteParamValue/ExpressionValues.php
+++ b/src/Attribute/RouteParamValue/ExpressionValues.php
@@ -9,7 +9,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 final class ExpressionValues extends AbstractValues
 {
-    private readonly Expression $expression;
+    public readonly Expression $expression;
 
     public function __construct(
         string|Expression $expression,
@@ -18,19 +18,11 @@ final class ExpressionValues extends AbstractValues
     }
 
     /**
-     * @return list<Expression>
+     * @return non-empty-list<string>
      */
-    public function getValues(): array
+    protected function getValues(): array
     {
-        return [$this->expression];
-    }
-
-    public function toArray(): array
-    {
-        return [
-            'type' => self::type(),
-            'values' => [(string) $this->expression],
-        ];
+        return [(string) $this->expression];
     }
 
     public static function type(): string

--- a/src/Attribute/RouteParamValue/PropertyValues.php
+++ b/src/Attribute/RouteParamValue/PropertyValues.php
@@ -7,7 +7,7 @@ namespace Sofascore\PurgatoryBundle\Attribute\RouteParamValue;
 final class PropertyValues extends AbstractValues
 {
     /** @var non-empty-list<string> */
-    private readonly array $properties;
+    public readonly array $properties;
 
     public function __construct(
         string $property,
@@ -19,7 +19,7 @@ final class PropertyValues extends AbstractValues
     /**
      * @return non-empty-list<string>
      */
-    public function getValues(): array
+    protected function getValues(): array
     {
         return $this->properties;
     }

--- a/src/Attribute/RouteParamValue/RawValues.php
+++ b/src/Attribute/RouteParamValue/RawValues.php
@@ -7,7 +7,7 @@ namespace Sofascore\PurgatoryBundle\Attribute\RouteParamValue;
 final class RawValues extends AbstractValues
 {
     /** @var non-empty-list<?scalar> */
-    private readonly array $values;
+    public readonly array $values;
 
     public function __construct(
         int|float|string|bool|null $value,
@@ -19,7 +19,7 @@ final class RawValues extends AbstractValues
     /**
      * @return non-empty-list<?scalar>
      */
-    public function getValues(): array
+    protected function getValues(): array
     {
         return $this->values;
     }

--- a/src/Attribute/RouteParamValue/ValuesInterface.php
+++ b/src/Attribute/RouteParamValue/ValuesInterface.php
@@ -7,11 +7,6 @@ namespace Sofascore\PurgatoryBundle\Attribute\RouteParamValue;
 interface ValuesInterface
 {
     /**
-     * @return list<mixed>
-     */
-    public function getValues(): array;
-
-    /**
      * @return array{type: string, values: list<mixed>}
      */
     public function toArray(): array;

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/CompoundInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/CompoundInverseValuesBuilder.php
@@ -30,7 +30,7 @@ final class CompoundInverseValuesBuilder implements InverseValuesBuilderInterfac
                 fn (ValuesInterface $values): ValuesInterface => $this->getInverseValuesBuilderFor($values)
                     ?->build($values, $associationClass, $associationTarget)
                     ?? $values,
-                $values->getValues(),
+                $values->values,
             ),
         );
     }

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/DynamicInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/DynamicInverseValuesBuilder.php
@@ -19,12 +19,9 @@ final class DynamicInverseValuesBuilder implements InverseValuesBuilderInterface
 
     public function build(ValuesInterface $values, string $associationClass, string $associationTarget): ValuesInterface
     {
-        $alias = $values->alias;
-        $arg = $values->arg;
-
         return new DynamicValues(
-            alias: $alias,
-            arg: null !== $arg ? \sprintf('%s?.%s', $associationTarget, $arg) : $associationTarget,
+            alias: $values->alias,
+            arg: null !== $values->arg ? \sprintf('%s?.%s', $associationTarget, $values->arg) : $associationTarget,
         );
     }
 }

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/DynamicInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/DynamicInverseValuesBuilder.php
@@ -21,7 +21,7 @@ final class DynamicInverseValuesBuilder implements InverseValuesBuilderInterface
     {
         return new DynamicValues(
             alias: $values->alias,
-            arg: null !== $values->arg ? \sprintf('%s?.%s', $associationTarget, $values->arg) : $associationTarget,
+            propertyPath: null !== $values->propertyPath ? \sprintf('%s?.%s', $associationTarget, $values->propertyPath) : $associationTarget,
         );
     }
 }

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/DynamicInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/DynamicInverseValuesBuilder.php
@@ -19,8 +19,8 @@ final class DynamicInverseValuesBuilder implements InverseValuesBuilderInterface
 
     public function build(ValuesInterface $values, string $associationClass, string $associationTarget): ValuesInterface
     {
-        /** @var string $alias */
-        [$alias, $arg] = $values->getValues();
+        $alias = $values->alias;
+        $arg = $values->arg;
 
         return new DynamicValues(
             alias: $alias,

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/ExpressionInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/ExpressionInverseValuesBuilder.php
@@ -25,7 +25,7 @@ final class ExpressionInverseValuesBuilder implements InverseValuesBuilderInterf
 
     public function build(ValuesInterface $values, string $associationClass, string $associationTarget): ValuesInterface
     {
-        [$expression] = $values->getValues();
+        $expression = $values->expression;
 
         $inverseExpression = $this->expressionTransformer->transform($expression, $associationClass, $associationTarget, 'null');
 

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/ExpressionInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/ExpressionInverseValuesBuilder.php
@@ -25,10 +25,8 @@ final class ExpressionInverseValuesBuilder implements InverseValuesBuilderInterf
 
     public function build(ValuesInterface $values, string $associationClass, string $associationTarget): ValuesInterface
     {
-        $expression = $values->expression;
-
-        $inverseExpression = $this->expressionTransformer->transform($expression, $associationClass, $associationTarget, 'null');
-
-        return new ExpressionValues($inverseExpression);
+        return new ExpressionValues(
+            expression: $this->expressionTransformer->transform($values->expression, $associationClass, $associationTarget, 'null'),
+        );
     }
 }

--- a/src/Cache/PropertyResolver/InverseValuesBuilder/PropertyInverseValuesBuilder.php
+++ b/src/Cache/PropertyResolver/InverseValuesBuilder/PropertyInverseValuesBuilder.php
@@ -21,7 +21,7 @@ final class PropertyInverseValuesBuilder implements InverseValuesBuilderInterfac
     {
         return new PropertyValues(...array_map(
             static fn (string $property): string => \sprintf('%s?.%s', $associationTarget, $property),
-            $values->getValues(),
+            $values->properties,
         ));
     }
 }

--- a/src/Cache/Subscription/PurgeSubscriptionProvider.php
+++ b/src/Cache/Subscription/PurgeSubscriptionProvider.php
@@ -76,7 +76,7 @@ final class PurgeSubscriptionProvider implements PurgeSubscriptionProviderInterf
             } else {
                 foreach ($purgeOn->routeParams as $values) {
                     if ($values instanceof ExpressionValues) {
-                        $this->validateExpression($values->getValues()[0], $routeMetadata->routeName);
+                        $this->validateExpression($values->expression, $routeMetadata->routeName);
                     }
                 }
                 $this->validateRouteParams(array_keys($purgeOn->routeParams), $routeMetadata);

--- a/tests/Attribute/RouteParamValue/CompoundValuesTest.php
+++ b/tests/Attribute/RouteParamValue/CompoundValuesTest.php
@@ -23,7 +23,7 @@ final class CompoundValuesTest extends TestCase
     {
         $compoundValues = new CompoundValues(...$values);
 
-        self::assertEquals($expectedValues, $compoundValues->getValues());
+        self::assertEquals($expectedValues, $compoundValues->values);
     }
 
     public function testExceptionIsThrownOnSelf(): void

--- a/tests/Attribute/RouteParamValue/ExpressionValuesTest.php
+++ b/tests/Attribute/RouteParamValue/ExpressionValuesTest.php
@@ -17,8 +17,6 @@ final class ExpressionValuesTest extends TestCase
     #[TestWith([new Expression('obj.getHeight() * obj.getWidth()')])]
     public function testValueNormalization(string|Expression $expression): void
     {
-        $value = (new ExpressionValues($expression))->expression;
-
-        self::assertSame((string) $expression, (string) $value);
+        self::assertSame((string) $expression, (string) (new ExpressionValues($expression))->expression);
     }
 }

--- a/tests/Attribute/RouteParamValue/ExpressionValuesTest.php
+++ b/tests/Attribute/RouteParamValue/ExpressionValuesTest.php
@@ -17,10 +17,8 @@ final class ExpressionValuesTest extends TestCase
     #[TestWith([new Expression('obj.getHeight() * obj.getWidth()')])]
     public function testValueNormalization(string|Expression $expression): void
     {
-        $values = (new ExpressionValues($expression))->getValues();
+        $value = (new ExpressionValues($expression))->expression;
 
-        self::assertArrayHasKey(0, $values);
-        self::assertInstanceOf(Expression::class, $values[0]);
-        self::assertSame((string) $expression, (string) $values[0]);
+        self::assertSame((string) $expression, (string) $value);
     }
 }

--- a/tests/Cache/PropertyResolver/InverseValuesBuildersTest.php
+++ b/tests/Cache/PropertyResolver/InverseValuesBuildersTest.php
@@ -52,7 +52,7 @@ final class InverseValuesBuildersTest extends TestCase
 
         $compoundValues = new CompoundValues(
             new DynamicValues('alias'),
-            new DynamicValues('alias', arg: 'obj'),
+            new DynamicValues('alias', propertyPath: 'obj'),
             new EnumValues(DummyIntEnum::class),
             new PropertyValues('obj'),
             new RawValues(1, null, 'str'),
@@ -61,10 +61,10 @@ final class InverseValuesBuildersTest extends TestCase
 
         self::assertEquals(
             expected: new CompoundValues(
-                new DynamicValues('alias', arg: 'association'),
+                new DynamicValues('alias', propertyPath: 'association'),
                 new DynamicValues(
                     alias: 'alias',
-                    arg: 'association?.obj',
+                    propertyPath: 'association?.obj',
                 ),
                 new EnumValues(DummyIntEnum::class),
                 new PropertyValues('association?.obj'),

--- a/tests/Functional/TestApplication/Controller/AnimalController.php
+++ b/tests/Functional/TestApplication/Controller/AnimalController.php
@@ -115,7 +115,7 @@ class AnimalController
             'rating' => new CompoundValues(
                 new DynamicValues(alias: 'purgatory.animal_rating2'),
                 new DynamicValues(alias: 'purgatory.animal_rating1'),
-                new DynamicValues(alias: 'purgatory.animal_rating3', arg: 'owner'),
+                new DynamicValues(alias: 'purgatory.animal_rating3', propertyPath: 'owner'),
             ),
         ],
     )]


### PR DESCRIPTION
`CompoundValues` no longer extend `AbstractValues` - it direclty implements `ValueInterface` because of custom implementiation of `toArray`

`getValues` should not be used outside of `AbstractValues` and `toArray`. inverse builders know exactly which type of values they are handling, so they can directly access properties (they are now public)