### PR TITLE
Skip calculating old value when PersistentCollection is in change set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-06-10
+
+### Fixed
+
+- Fix purge route generation when Doctrine change sets contain a `PersistentCollection` by @Brajk19
+  in https://github.com/sofascore/purgatory-bundle/pull/144
+
 ## [1.3.1] - 2026-06-08
 
 ### Fixed
@@ -55,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[1.3.2]: https://github.com/sofascore/purgatory-bundle/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/sofascore/purgatory-bundle/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/sofascore/purgatory-bundle/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/sofascore/purgatory-bundle/compare/v1.2.0...v1.2.1

--- a/src/Listener/EntityChangeListener.php
+++ b/src/Listener/EntityChangeListener.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PostPersistEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Event\PreRemoveEventArgs;
+use Doctrine\ORM\PersistentCollection;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 use Sofascore\PurgatoryBundle\Purger\PurgeRequest;
@@ -76,7 +77,7 @@ final class EntityChangeListener
     {
         $entity = $eventArgs->getObject();
 
-        /** @var array<string, array{mixed, mixed}> $entityChangeSet */
+        /** @var array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet */
         $entityChangeSet = $eventArgs->getObjectManager()->getUnitOfWork()->getEntityChangeSet($entity);
 
         foreach ($this->routeProviders as $routeProvider) {

--- a/src/Listener/EntityChangeListener.php
+++ b/src/Listener/EntityChangeListener.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PostPersistEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Event\PreRemoveEventArgs;
-use Doctrine\ORM\PersistentCollection;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 use Sofascore\PurgatoryBundle\Purger\PurgeRequest;
@@ -76,8 +75,6 @@ final class EntityChangeListener
     private function handleChanges(LifecycleEventArgs $eventArgs, Action $action): void
     {
         $entity = $eventArgs->getObject();
-
-        /** @var array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet */
         $entityChangeSet = $eventArgs->getObjectManager()->getUnitOfWork()->getEntityChangeSet($entity);
 
         foreach ($this->routeProviders as $routeProvider) {

--- a/src/RouteProvider/AbstractEntityRouteProvider.php
+++ b/src/RouteProvider/AbstractEntityRouteProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\RouteProvider;
 
+use Doctrine\ORM\PersistentCollection;
 use Psr\Container\ContainerInterface;
 use Sofascore\PurgatoryBundle\Cache\Configuration\Configuration;
 use Sofascore\PurgatoryBundle\Cache\Configuration\ConfigurationLoaderInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 abstract class AbstractEntityRouteProvider implements RouteProviderInterface
 {
     /**
-     * @param array<string, array{mixed, mixed}> $entityChangeSet
+     * @param array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet
      *
      * @return array<int, string>
      */
@@ -61,7 +62,7 @@ abstract class AbstractEntityRouteProvider implements RouteProviderInterface
     }
 
     /**
-     * @param array<string, array{mixed, mixed}> $entityChangeSet
+     * @param array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet
      *
      * @return iterable<int, PurgeRoute>
      */
@@ -113,9 +114,9 @@ abstract class AbstractEntityRouteProvider implements RouteProviderInterface
     }
 
     /**
-     * @param array<string, list<?scalar>>                                             $routeParamValues
-     * @param array<string, array{type: string, values: list<mixed>, optional?: true}> $routeParamConfigs
-     * @param array<string, array{mixed, mixed}>                                       $entityChangeSet
+     * @param array<string, list<?scalar>>                                               $routeParamValues
+     * @param array<string, array{type: string, values: list<mixed>, optional?: true}>   $routeParamConfigs
+     * @param array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet
      *
      * @return list<array<string, ?scalar>>
      */

--- a/src/RouteProvider/RouteProviderInterface.php
+++ b/src/RouteProvider/RouteProviderInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\RouteProvider;
 
+use Doctrine\ORM\PersistentCollection;
 use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 
 /**
@@ -12,8 +13,8 @@ use Sofascore\PurgatoryBundle\Listener\Enum\Action;
 interface RouteProviderInterface
 {
     /**
-     * @param T                                  $entity
-     * @param array<string, array{mixed, mixed}> $entityChangeSet
+     * @param T                                                                          $entity
+     * @param array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet
      *
      * @return iterable<int, PurgeRoute>
      */

--- a/src/RouteProvider/UpdatedEntityRouteProvider.php
+++ b/src/RouteProvider/UpdatedEntityRouteProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\RouteProvider;
 
+use Doctrine\ORM\PersistentCollection;
 use Psr\Container\ContainerInterface;
 use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\PropertyValues;
 use Sofascore\PurgatoryBundle\Cache\Configuration\ConfigurationLoaderInterface;
@@ -94,8 +95,8 @@ final class UpdatedEntityRouteProvider extends AbstractEntityRouteProvider
     /**
      * If possible, compute the old values for the route params.
      *
-     * @param array<string, array{mixed, mixed}>                        $entityChangeSet
-     * @param array{type: string, values: list<mixed>, optional?: true} $config
+     * @param array<string, array{mixed, mixed}|PersistentCollection<array-key, object>> $entityChangeSet
+     * @param array{type: string, values: list<mixed>, optional?: true}                  $config
      *
      * @return list<?scalar>
      */
@@ -132,6 +133,11 @@ final class UpdatedEntityRouteProvider extends AbstractEntityRouteProvider
 
             // Association check
             $head = $propertyPath->getElement(0);
+
+            // a dereferenced to-many association holds the old collection instead of an [old, new] pair
+            if (($entityChangeSet[$head] ?? null) instanceof PersistentCollection) {
+                continue;
+            }
 
             if (!isset($entityChangeSet[$head][0])) {
                 continue;

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\Tests\Application;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use Sofascore\PurgatoryBundle\Test\InteractsWithPurgatory;
@@ -414,6 +415,43 @@ final class ApplicationTest extends AbstractKernelTestCase
 
         self::assertUrlIsPurged('/animal/'.$pet1->id.'/owner-details');
         self::assertUrlIsPurged('/animal/'.$pet2->id.'/owner-details');
+    }
+
+    /**
+     * @see AnimalController::petOwnerDetails
+     */
+    public function testPurgeAfterCollectionDereference(): void
+    {
+        $person = new Person();
+        $person->firstName = 'Purga';
+        $person->lastName = 'Tory';
+        $person->gender = 'male';
+
+        $pet1 = new Animal();
+        $pet1->name = 'Poppy';
+        $pet1->owner = $person;
+        $person->pets->add($pet1);
+
+        $pet2 = new Animal();
+        $pet2->name = 'Bobby';
+        $pet2->owner = $person;
+        $person->pets->add($pet2);
+
+        $this->entityManager->persist($person);
+        $this->entityManager->flush();
+
+        self::assertUrlIsPurged('/animal/'.$pet1->id.'/owner-details');
+        self::assertUrlIsPurged('/animal/'.$pet2->id.'/owner-details');
+
+        self::clearPurger();
+
+        // the entity change set now contains the old collection instead of an [old, new] pair
+        $person->pets = new ArrayCollection([$pet1]);
+        $this->entityManager->flush();
+
+        self::assertUrlIsPurged('/animal/'.$pet1->id.'/owner-details');
+        // old values are not computed for a dereferenced collection
+        self::assertUrlIsNotPurged('/animal/'.$pet2->id.'/owner-details');
     }
 
     /**

--- a/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
+++ b/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
@@ -270,9 +270,9 @@ final class UpdatedEntityRouteProviderTest extends TestCase
             entity: $entity,
             entityChangeSet: [
                 'pets' => new PersistentCollection(
-                    em: self::createStub(EntityManagerInterface::class),
-                    typeClass: new ClassMetadata(\stdClass::class),
-                    collection: new ArrayCollection([$oldPet1, $oldPet2]),
+                    self::createStub(EntityManagerInterface::class),
+                    new ClassMetadata(\stdClass::class),
+                    new ArrayCollection([$oldPet1, $oldPet2]),
                 ),
             ],
         )];

--- a/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
+++ b/tests/RouteProvider/UpdatedEntityRouteProviderTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Sofascore\PurgatoryBundle\Tests\RouteProvider;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\PersistentCollection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -232,6 +236,51 @@ final class UpdatedEntityRouteProviderTest extends TestCase
         self::assertSame(['name' => 'foo_route', 'params' => ['param1' => 'two']], (array) $routes[2]);
         self::assertSame(['name' => 'embeddable_route', 'params' => ['param1' => 4]], (array) $routes[3]);
         self::assertSame(['name' => 'association_route', 'params' => ['param1' => 5]], (array) $routes[4]);
+    }
+
+    public function testOldValuesFromDereferencedCollectionAreSkipped(): void
+    {
+        $routeProvider = $this->createRouteProvider([
+            'stdClass::pets' => [
+                [
+                    'routeName' => 'pets_route',
+                    'routeParams' => [
+                        'param1' => [
+                            'type' => PropertyValues::type(),
+                            'values' => ['pets[*].id'],
+                        ],
+                    ],
+                ],
+            ],
+        ], false);
+
+        $newPet = new \stdClass();
+        $newPet->id = 3;
+
+        $entity = new \stdClass();
+        $entity->pets = new ArrayCollection([$newPet]);
+
+        $oldPet1 = new \stdClass();
+        $oldPet1->id = 1;
+        $oldPet2 = new \stdClass();
+        $oldPet2->id = 2;
+
+        $routes = [...$routeProvider->provideRoutesFor(
+            action: Action::Update,
+            entity: $entity,
+            entityChangeSet: [
+                'pets' => new PersistentCollection(
+                    em: self::createStub(EntityManagerInterface::class),
+                    typeClass: new ClassMetadata(\stdClass::class),
+                    collection: new ArrayCollection([$oldPet1, $oldPet2]),
+                ),
+            ],
+        )];
+
+        self::assertCount(1, $routes);
+        self::assertContainsOnlyInstancesOf(PurgeRoute::class, $routes);
+
+        self::assertSame(['name' => 'pets_route', 'params' => ['param1' => 3]], (array) $routes[0]);
     }
 
     public function testProvideRoutesToPurgeWithArrayAccess(): void


### PR DESCRIPTION
**Summary 📝**

The entity change set is not always in the `[old, new]` format — when a to-many collection is replaced with a new collection instance, Doctrine puts the old `PersistentCollection` itself into the change set. The old route param value computation assumed the pair format and crashed during flush with an `InvalidPropertyPathException` when a route param path like `pets[*].id` hit such an entry.


**Checklist ✅**
- [x] Tests updated 🐛
- [ ] ~Docs updated 📚~
- [x] Changelog updated 📋
- [ ] ~Breaking change ⚠️~
