### PR TITLE
Use ".kernel.config_dir" for YAML mapping discovery, fall back to project dir

### DIFF
--- a/src/DependencyInjection/PurgatoryExtension.php
+++ b/src/DependencyInjection/PurgatoryExtension.php
@@ -214,9 +214,16 @@ final class PurgatoryExtension extends ConfigurableExtension implements PrependE
             }
         };
 
-        /** @var string $projectDir */
-        $projectDir = $container->getParameter('kernel.project_dir');
-        if ($container->fileExists($dir = $projectDir.'/config/purgatory', '/^$/')) {
+        if ($container->hasParameter('.kernel.config_dir')) {
+            /** @var string $configDir */
+            $configDir = $container->getParameter('.kernel.config_dir');
+        } else {
+            /** @var string $projectDir */
+            $projectDir = $container->getParameter('kernel.project_dir');
+            $configDir = $projectDir.'/config';
+        }
+
+        if ($container->fileExists($dir = $configDir.'/purgatory', '/^$/')) {
             yield from $registerMappingFilesFromDir($dir);
         }
 

--- a/tests/DependencyInjection/PurgatoryExtensionTest.php
+++ b/tests/DependencyInjection/PurgatoryExtensionTest.php
@@ -239,6 +239,61 @@ final class PurgatoryExtensionTest extends TestCase
         ));
     }
 
+    public function testMappingFilesAreLoadedFromProjectConfigDirWhenConfigDirParamIsNotSet(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', __DIR__.'/Fixtures/app');
+
+        $extension = new PurgatoryExtension();
+        $extension->load([], $container);
+
+        self::assertTrue($container->hasDefinition('sofascore.purgatory.route_metadata_provider.yaml'));
+        self::assertSame(
+            [
+                __DIR__.'/Fixtures/app/config/purgatory/one.yaml',
+                __DIR__.'/Fixtures/app/config/purgatory/two.yml',
+            ],
+            $container->getDefinition('sofascore.purgatory.route_metadata_provider.yaml')->getArgument(1),
+        );
+    }
+
+    public function testMappingFilesAreLoadedOnlyFromKernelConfigDirWhenSet(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', __DIR__.'/Fixtures/app');
+        $container->setParameter('.kernel.config_dir', __DIR__.'/Fixtures/app/apps/sub/config');
+
+        $extension = new PurgatoryExtension();
+        $extension->load([], $container);
+
+        self::assertTrue($container->hasDefinition('sofascore.purgatory.route_metadata_provider.yaml'));
+        self::assertSame(
+            [
+                __DIR__.'/Fixtures/app/apps/sub/config/purgatory/six.yaml',
+            ],
+            $container->getDefinition('sofascore.purgatory.route_metadata_provider.yaml')->getArgument(1),
+        );
+    }
+
+    public function testMappingFilesAreLoadedOnceWhenKernelConfigDirMatchesProjectConfigDir(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', __DIR__.'/Fixtures/app');
+        $container->setParameter('.kernel.config_dir', __DIR__.'/Fixtures/app/config');
+
+        $extension = new PurgatoryExtension();
+        $extension->load([], $container);
+
+        self::assertTrue($container->hasDefinition('sofascore.purgatory.route_metadata_provider.yaml'));
+        self::assertSame(
+            [
+                __DIR__.'/Fixtures/app/config/purgatory/one.yaml',
+                __DIR__.'/Fixtures/app/config/purgatory/two.yml',
+            ],
+            $container->getDefinition('sofascore.purgatory.route_metadata_provider.yaml')->getArgument(1),
+        );
+    }
+
     public function testYamlMetadataProviderIsRemovedWhenThereAreNoFiles(): void
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
**Summary 📝**

The extension currently hardcodes the YAML mapping discovery path to `%kernel.project_dir%/config/purgatory`. 

In a monorepo with multiple kernels (one shared project dir, per-app config dirs via a `getConfigDir()` override), every app ends up loading the mappings of whichever app keeps its config in `<project_dir>/config` .

This PR makes the extension use the `.kernel.config_dir` parameter (set by `MicroKernelTrait::getKernelParameters()` since Symfony 6.1) to locate `<config_dir>/purgatory`, falling back to `<project_dir>/config/purgatory` for kernels that don't use `MicroKernelTrait`. For standard single-app setups both paths are identical, so behavior is unchanged.

On Symfony 5.4, where `.kernel.config_dir` does not exist yet, the fallback always applies, so the current behavior is fully preserved there as well - only the per-app config dir resolution is unavailable.

Covered cases (see `PurgatoryExtensionTest`):
- no `.kernel.config_dir` param → mappings load from `<project_dir>/config/purgatory` (BC)
- param set → mappings load only from `<config_dir>/purgatory`, not from `<project_dir>/config`
- param equal to `<project_dir>/config` → each mapping file is loaded exactly once

**Checklist ✅**
- [x] Tests updated 🐛
