### PR TITLE
Replace deprecated `defaultIndexMethod` usage with a compiler pass

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -72,7 +72,7 @@ return static function (ContainerConfigurator $container) {
                 tagged_iterator('purgatory.subscription_resolver'),
                 tagged_iterator('purgatory.route_metadata_provider'),
                 service('doctrine'),
-                tagged_locator('purgatory.target_resolver', defaultIndexMethod: 'for'),
+                tagged_locator('purgatory.target_resolver', indexAttribute: 'for'),
                 service('sofascore.purgatory.expression_language')->nullOnInvalid(),
             ])
 
@@ -142,7 +142,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('sofascore.purgatory.configuration_loader'),
                 service('sofascore.purgatory.expression_language')->nullOnInvalid(),
-                tagged_locator('purgatory.route_param_value_resolver', defaultIndexMethod: 'for'),
+                tagged_locator('purgatory.route_param_value_resolver', indexAttribute: 'for'),
             ])
 
         ->set('sofascore.purgatory.route_provider.created_entity', CreatedEntityRouteProvider::class)
@@ -202,7 +202,7 @@ return static function (ContainerConfigurator $container) {
         ->set('sofascore.purgatory.route_param_value_resolver.compound', CompoundValuesResolver::class)
             ->tag('purgatory.route_param_value_resolver')
             ->args([
-                tagged_locator('purgatory.route_param_value_resolver', defaultIndexMethod: 'for'),
+                tagged_locator('purgatory.route_param_value_resolver', indexAttribute: 'for'),
             ])
 
         ->set('sofascore.purgatory.route_param_value_resolver.enum', EnumValuesResolver::class)

--- a/src/DependencyInjection/CompilerPass/ResolveTaggedLocatorIndexPass.php
+++ b/src/DependencyInjection/CompilerPass/ResolveTaggedLocatorIndexPass.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass;
+
+use Sofascore\PurgatoryBundle\Attribute\Target\TargetInterface;
+use Sofascore\PurgatoryBundle\Cache\TargetResolver\TargetResolverInterface;
+use Sofascore\PurgatoryBundle\Exception\RuntimeException;
+use Sofascore\PurgatoryBundle\RouteParamValueResolver\ValuesResolverInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Sets the "for" tag attribute used as the service locator index from the tagged
+ * class's static "for()" method, replacing the "defaultIndexMethod" reflection
+ * fallback which is deprecated since Symfony 8.1.
+ */
+final class ResolveTaggedLocatorIndexPass implements CompilerPassInterface
+{
+    private const TAG_TO_INTERFACE = [
+        'purgatory.target_resolver' => TargetResolverInterface::class,
+        'purgatory.route_param_value_resolver' => ValuesResolverInterface::class,
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::TAG_TO_INTERFACE as $tagName => $interface) {
+            /** @var list<array<string, mixed>> $tags */
+            foreach ($container->findTaggedServiceIds($tagName, true) as $id => $tags) {
+                if (!array_any($tags, static fn (array $attributes): bool => !isset($attributes['for']))) {
+                    continue;
+                }
+
+                $definition = $container->getDefinition($id);
+                $class = $definition->getClass();
+
+                $parent = $definition;
+                while (null === $class && $parent instanceof ChildDefinition) {
+                    $parent = $container->findDefinition($parent->getParent());
+                    $class = $parent->getClass();
+                }
+
+                /** @var ?class-string<TargetResolverInterface<TargetInterface>|ValuesResolverInterface<array<mixed>>> $class */
+                $class = $container->getParameterBag()->resolveValue($class);
+
+                if (!\is_string($class)) {
+                    throw new RuntimeException(\sprintf('The class of the service "%s" tagged with "%s" could not be determined.', $id, $tagName));
+                }
+
+                if (!is_a($class, $interface, true)) {
+                    throw new RuntimeException(\sprintf('The class "%s" of the service "%s" tagged with "%s" must implement "%s".', $class, $id, $tagName, $interface));
+                }
+
+                $for = $class::for();
+
+                $definition->clearTag($tagName);
+                foreach ($tags as $attributes) {
+                    $definition->addTag($tagName, $attributes + ['for' => $for]);
+                }
+            }
+        }
+    }
+}

--- a/src/PurgatoryBundle.php
+++ b/src/PurgatoryBundle.php
@@ -8,6 +8,8 @@ use Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass\ControllerClassMa
 use Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass\RegisterExpressionLanguageProvidersPass;
 use Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass\RegisterPurgerPass;
 use Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass\RegisterRouteParamServicesPass;
+use Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass\ResolveTaggedLocatorIndexPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -19,6 +21,9 @@ final class PurgatoryBundle extends Bundle
         $container->addCompilerPass(new RegisterExpressionLanguageProvidersPass());
         $container->addCompilerPass(new RegisterPurgerPass());
         $container->addCompilerPass(new RegisterRouteParamServicesPass());
+        // Runs after all before-optimization passes so that late-added tags are seen,
+        // but before ServiceLocatorTagPass which consumes the "for" attribute.
+        $container->addCompilerPass(new ResolveTaggedLocatorIndexPass(), PassConfig::TYPE_OPTIMIZE, 1);
     }
 
     public function getPath(): string

--- a/tests/DependencyInjection/CompilerPass/ResolveTaggedLocatorIndexPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/ResolveTaggedLocatorIndexPassTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sofascore\PurgatoryBundle\Tests\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sofascore\PurgatoryBundle\Attribute\RouteParamValue\RawValues;
+use Sofascore\PurgatoryBundle\Attribute\Target\ForProperties;
+use Sofascore\PurgatoryBundle\Cache\TargetResolver\ForPropertiesResolver;
+use Sofascore\PurgatoryBundle\DependencyInjection\CompilerPass\ResolveTaggedLocatorIndexPass;
+use Sofascore\PurgatoryBundle\Exception\RuntimeException;
+use Sofascore\PurgatoryBundle\RouteParamValueResolver\RawValuesResolver;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+#[CoversClass(ResolveTaggedLocatorIndexPass::class)]
+final class ResolveTaggedLocatorIndexPassTest extends TestCase
+{
+    public function testForAttributeIsResolvedFromTheTaggedClass(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo', class: ForPropertiesResolver::class)
+            ->addTag(name: 'purgatory.target_resolver');
+        $container->register(id: 'bar', class: RawValuesResolver::class)
+            ->addTag(name: 'purgatory.route_param_value_resolver', attributes: ['priority' => 10]);
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+
+        self::assertSame(
+            [['for' => ForProperties::class]],
+            $container->getDefinition('foo')->getTag('purgatory.target_resolver'),
+        );
+        self::assertSame(
+            [['priority' => 10, 'for' => RawValues::type()]],
+            $container->getDefinition('bar')->getTag('purgatory.route_param_value_resolver'),
+        );
+    }
+
+    public function testExistingKeyIsNotOverwritten(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo', class: ForPropertiesResolver::class)
+            ->addTag(name: 'purgatory.target_resolver', attributes: ['for' => \stdClass::class]);
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+
+        self::assertSame(
+            [['for' => \stdClass::class]],
+            $container->getDefinition('foo')->getTag('purgatory.target_resolver'),
+        );
+    }
+
+    public function testClassIsNotValidatedWhenAllTagsHaveAnExplicitKey(): void
+    {
+        // Both definitions would fail validation ("foo" does not implement the expected
+        // interface, "bar" has no class), so this test only passes if services whose
+        // tags all have an explicit "for" attribute are skipped before validation.
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo', class: \stdClass::class)
+            ->addTag(name: 'purgatory.target_resolver', attributes: ['for' => \stdClass::class]);
+        $container->register(id: 'bar')
+            ->addTag(name: 'purgatory.route_param_value_resolver', attributes: ['for' => \stdClass::class]);
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+
+        self::assertSame(
+            [['for' => \stdClass::class]],
+            $container->getDefinition('foo')->getTag('purgatory.target_resolver'),
+        );
+        self::assertSame(
+            [['for' => \stdClass::class]],
+            $container->getDefinition('bar')->getTag('purgatory.route_param_value_resolver'),
+        );
+    }
+
+    public function testOnlyTagsWithoutAnExplicitKeyAreStamped(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo', class: ForPropertiesResolver::class)
+            ->addTag(name: 'purgatory.target_resolver', attributes: ['for' => \stdClass::class])
+            ->addTag(name: 'purgatory.target_resolver');
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+
+        self::assertSame(
+            [['for' => \stdClass::class], ['for' => ForProperties::class]],
+            $container->getDefinition('foo')->getTag('purgatory.target_resolver'),
+        );
+    }
+
+    public function testClassIsResolvedFromParentDefinition(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo', class: ForPropertiesResolver::class);
+        $container->setDefinition(
+            id: 'bar',
+            definition: (new ChildDefinition('foo'))->addTag(name: 'purgatory.target_resolver'),
+        );
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+
+        self::assertSame(
+            [['for' => ForProperties::class]],
+            $container->getDefinition('bar')->getTag('purgatory.target_resolver'),
+        );
+    }
+
+    public function testClassIsResolvedFromParameter(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('foo.class', ForPropertiesResolver::class);
+        $container->register(id: 'foo', class: '%foo.class%')
+            ->addTag(name: 'purgatory.target_resolver');
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+
+        self::assertSame(
+            [['for' => ForProperties::class]],
+            $container->getDefinition('foo')->getTag('purgatory.target_resolver'),
+        );
+    }
+
+    public function testExceptionIsThrownWhenClassCannotBeDetermined(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo')
+            ->addTag(name: 'purgatory.target_resolver');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The class of the service "foo" tagged with "purgatory.target_resolver" could not be determined.');
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+    }
+
+    public function testExceptionIsThrownWhenClassResolvesToANonStringValue(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('foo.class', ['not', 'a', 'class']);
+        $container->register(id: 'foo', class: '%foo.class%')
+            ->addTag(name: 'purgatory.target_resolver');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The class of the service "foo" tagged with "purgatory.target_resolver" could not be determined.');
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+    }
+
+    public function testExceptionIsThrownWhenClassDoesNotImplementExpectedInterface(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(id: 'foo', class: \stdClass::class)
+            ->addTag(name: 'purgatory.route_param_value_resolver');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The class "stdClass" of the service "foo" tagged with "purgatory.route_param_value_resolver" must implement "Sofascore\PurgatoryBundle\RouteParamValueResolver\ValuesResolverInterface".');
+
+        (new ResolveTaggedLocatorIndexPass())->process($container);
+    }
+}


### PR DESCRIPTION
**Summary 📝**

Symfony 8.1 [deprecates the `defaultIndexMethod` option of `tagged_locator()`](https://github.com/symfony/symfony/pull/62339) in favor of the `#[AsTaggedItem]` attribute. That attribute is not a viable replacement here, the locator index comes from the public static `for()` method on `TargetResolverInterface` and `ValuesResolverInterface`.

A new `ResolveTaggedLocatorIndexPass` calls `for()` itself during compilation and stamps the result onto each `purgatory.target_resolver` and `purgatory.route_param_value_resolver` tag as a `for` attribute, which the `tagged_locator()` calls now use via `indexAttribute: 'for'`.

**Checklist ✅**
- [x] Tests updated 🐛
- [ ] Docs updated 📚
- [ ] Changelog updated 📋
- [ ] Breaking change ⚠️
