### PR TITLE
Remove Symfony 8.0 from CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,17 +19,11 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
-                symfony: [ '5.4', '6.4', '7.4', '8.0', '8.1' ]
+                symfony: [ '5.4', '6.4', '7.4', '8.1' ]
                 dependencies: [ 'highest', 'lowest' ]
                 exclude:
                     -   php: '8.1'
                         symfony: '7.4'
-                    -   php: '8.1'
-                        symfony: '8.0'
-                    -   php: '8.2'
-                        symfony: '8.0'
-                    -   php: '8.3'
-                        symfony: '8.0'
                     -   php: '8.1'
                         symfony: '8.1'
                     -   php: '8.2'


### PR DESCRIPTION
**Summary 📝**

Symfony 8.0 is no longer supported, so we can remove it for CI as it's currently failing. 

**Checklist ✅**
- [ ] ~Tests updated 🐛~
- [ ] ~Docs updated 📚~
- [ ] ~Changelog updated 📋~
- [ ] ~Breaking change ⚠️~
